### PR TITLE
Import XYZ layer from saved project

### DIFF
--- a/XYZHubConnector/modules/layer/edit_buffer.py
+++ b/XYZHubConnector/modules/layer/edit_buffer.py
@@ -11,7 +11,7 @@
 from qgis.core import QgsVectorLayer
 from qgis.PyQt.QtCore import Qt
 
-from . import parser
+from . import parser, layer_props as QProps
 from .layer_utils import (get_feat_upload_from_iter, is_layer_committed,
                           is_xyz_supported_layer, make_xyz_id_map_from_src,
                           update_feat_non_null, get_conn_info_from_layer,
@@ -19,6 +19,7 @@ from .layer_utils import (get_feat_upload_from_iter, is_layer_committed,
 
 from ..common.signal import make_print_qgis
 print_qgis = make_print_qgis("edit_buffer")
+
 
 def make_cb_fun(fun, *a0, **kw0):
     def _fun(*a,**kw):
@@ -394,8 +395,8 @@ class EditBuffer(object):
         
         for vlayer in lst_vlayer:
             if not (isinstance(vlayer, QgsVectorLayer) and is_xyz_supported_layer(vlayer)): continue
-            if vlayer.customProperty("xyz-hub-edit") is not None: continue
-            vlayer.setCustomProperty("xyz-hub-edit", True)
+            if vlayer.customProperty(QProps.EDIT_FLAG) is not None: continue
+            vlayer.setCustomProperty(QProps.EDIT_FLAG, True)
 
 
             layer_id = vlayer.id()
@@ -409,7 +410,7 @@ class EditBuffer(object):
     def unload_connection(self):
         for c in self.layer_buffer.values():
             vlayer = get_layer(c.get_layer_id())
-            vlayer.removeCustomProperty("xyz-hub-edit")
+            vlayer.removeCustomProperty(QProps.EDIT_FLAG)
             c.unload_connection()
             
     def make_connection_pair(self, vlayer, layer_cache):

--- a/XYZHubConnector/modules/layer/edit_buffer.py
+++ b/XYZHubConnector/modules/layer/edit_buffer.py
@@ -11,7 +11,8 @@
 from qgis.core import QgsVectorLayer
 from qgis.PyQt.QtCore import Qt
 
-from . import parser, layer_props as QProps
+from . import parser
+from .layer_props import QProps
 from .layer_utils import (get_feat_upload_from_iter, is_layer_committed,
                           is_xyz_supported_layer, make_xyz_id_map_from_src,
                           update_feat_non_null, get_conn_info_from_layer,

--- a/XYZHubConnector/modules/layer/layer.py
+++ b/XYZHubConnector/modules/layer/layer.py
@@ -81,13 +81,16 @@ class XYZLayer(object):
                 obj._save_meta(vlayer)
         return obj
 
+    def save_params_to_node(self, qnode):
+        qnode.setCustomProperty(QProps.LOADER_PARAMS, json.dumps(self.get_loader_params(), ensure_ascii=False))
+        qnode.setCustomProperty(QProps.TAGS, self.tags)
+
     def _save_meta_node(self, qnode):
         qnode.setCustomProperty(QProps.LAYER_META, json.dumps(self.meta, ensure_ascii=False))
         qnode.setCustomProperty(QProps.CONN_INFO, json.dumps(self.conn_info.to_dict(), ensure_ascii=False))
-        qnode.setCustomProperty(QProps.LOADER_PARAMS, json.dumps(self.get_loader_params(), ensure_ascii=False))
-        qnode.setCustomProperty(QProps.TAGS, self.tags)
         qnode.setCustomProperty(QProps.UNIQUE_ID, self.get_id())
-
+        self.save_params_to_node(qnode)
+        
     def _save_meta(self, vlayer):
         self._save_meta_node(vlayer)
 

--- a/XYZHubConnector/modules/layer/layer.py
+++ b/XYZHubConnector/modules/layer/layer.py
@@ -20,8 +20,9 @@ from qgis.utils import iface
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 from qgis.PyQt.QtXml import QDomDocument
 
-from . import parser, render, layer_props as QProps
-from .layer_utils import get_feat_cnt_from_src, get_customProperty_str
+from . import parser, render
+from .layer_props import QProps
+from .layer_utils import get_feat_cnt_from_src, get_customProperty_str, load_json_none
 from ...models.space_model import parse_copyright
 from ...models import SpaceConnectionInfo
 from ...utils import make_unique_full_path, make_fixed_full_path
@@ -66,7 +67,7 @@ class XYZLayer(object):
         meta = json.loads(meta)
         conn_info = json.loads(conn_info)
         conn_info = SpaceConnectionInfo.from_dict(conn_info)
-        loader_params = json.loads(loader_params)
+        loader_params = load_json_none(loader_params)
 
         obj = cls(conn_info, meta, tags=tags, unique=unique, group_name=name, loader_params=loader_params)
         obj.qgroups["main"] = qnode
@@ -77,7 +78,7 @@ class XYZLayer(object):
                 geom_str = QgsWkbTypes.displayString(vlayer.wkbType())
                 obj.map_vlayer.setdefault(geom_str, list()).append(vlayer)
                 obj.map_fields.setdefault(geom_str, list()).append(vlayer.fields())
-                
+                obj._save_meta(vlayer)
         return obj
 
     def _save_meta_node(self, qnode):

--- a/XYZHubConnector/modules/layer/layer.py
+++ b/XYZHubConnector/modules/layer/layer.py
@@ -15,12 +15,12 @@ import json
 from qgis.core import (QgsCoordinateReferenceSystem, QgsFeatureRequest,
                        QgsProject, QgsVectorFileWriter, QgsVectorLayer, 
                        QgsCoordinateTransform, QgsWkbTypes)
-
+                
 from qgis.utils import iface
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 from qgis.PyQt.QtXml import QDomDocument
 
-from . import parser, render
+from . import parser, render, layer_props as QProps
 from .layer_utils import get_feat_cnt_from_src, get_customProperty_str
 from ...models.space_model import parse_copyright
 from ...models import SpaceConnectionInfo
@@ -29,8 +29,6 @@ from .style import LAYER_QML
 
 from ..common.signal import make_print_qgis
 print_qgis = make_print_qgis("layer")
-
-
 
 class XYZLayer(object):
     """ XYZ Layer is created in 2 scenarios:
@@ -59,11 +57,11 @@ class XYZLayer(object):
 
     @classmethod
     def load_from_qnode(cls, qnode):
-        meta = get_customProperty_str(qnode, "xyz-hub")
-        conn_info = get_customProperty_str(qnode, "xyz-hub-conn")
-        tags = get_customProperty_str(qnode, "xyz-hub-tags")
-        unique = get_customProperty_str(qnode, "xyz-hub-id")
-        loader_params = get_customProperty_str(qnode, "xyz-hub-loader")
+        meta = get_customProperty_str(qnode, QProps.LAYER_META)
+        conn_info = get_customProperty_str(qnode, QProps.CONN_INFO)
+        tags = get_customProperty_str(qnode, QProps.TAGS)
+        unique = get_customProperty_str(qnode, QProps.UNIQUE_ID)
+        loader_params = get_customProperty_str(qnode, QProps.LOADER_PARAMS)
         name = qnode.name()
         meta = json.loads(meta)
         conn_info = json.loads(conn_info)
@@ -83,11 +81,11 @@ class XYZLayer(object):
         return obj
 
     def _save_meta_node(self, qnode):
-        qnode.setCustomProperty("xyz-hub", json.dumps(self.meta, ensure_ascii=False))
-        qnode.setCustomProperty("xyz-hub-conn", json.dumps(self.conn_info.to_dict(), ensure_ascii=False))
-        qnode.setCustomProperty("xyz-hub-loader", json.dumps(self.get_loader_params(), ensure_ascii=False))
-        qnode.setCustomProperty("xyz-hub-tags", self.tags)
-        qnode.setCustomProperty("xyz-hub-id", self.get_id())
+        qnode.setCustomProperty(QProps.LAYER_META, json.dumps(self.meta, ensure_ascii=False))
+        qnode.setCustomProperty(QProps.CONN_INFO, json.dumps(self.conn_info.to_dict(), ensure_ascii=False))
+        qnode.setCustomProperty(QProps.LOADER_PARAMS, json.dumps(self.get_loader_params(), ensure_ascii=False))
+        qnode.setCustomProperty(QProps.TAGS, self.tags)
+        qnode.setCustomProperty(QProps.UNIQUE_ID, self.get_id())
 
     def _save_meta(self, vlayer):
         self._save_meta_node(vlayer)

--- a/XYZHubConnector/modules/layer/layer.py
+++ b/XYZHubConnector/modules/layer/layer.py
@@ -21,7 +21,7 @@ from qgis.PyQt.QtCore import QObject, pyqtSignal
 from qgis.PyQt.QtXml import QDomDocument
 
 from . import parser, render
-from .layer_utils import get_feat_cnt_from_src
+from .layer_utils import get_feat_cnt_from_src, get_customProperty_str
 from ...models.space_model import parse_copyright
 from ...models import SpaceConnectionInfo
 from ...utils import make_unique_full_path, make_fixed_full_path
@@ -48,7 +48,7 @@ class XYZLayer(object):
         self.conn_info = conn_info
         self.meta = meta
         self.tags = tags
-        self.unique = unique or int(time.time() * 10)
+        self.unique = str(unique or int(time.time() * 10))
         self._group_name = group_name
 
         self.map_vlayer = dict()
@@ -57,10 +57,10 @@ class XYZLayer(object):
 
     @classmethod
     def load_from_qnode(cls, qnode):
-        meta = qnode.customProperty("xyz-hub")
-        conn_info = qnode.customProperty("xyz-hub-conn")
-        tags = qnode.customProperty("xyz-hub-tags")
-        unique = qnode.customProperty("xyz-hub-id")
+        meta = get_customProperty_str(qnode, "xyz-hub")
+        conn_info = get_customProperty_str(qnode, "xyz-hub-conn")
+        tags = get_customProperty_str(qnode, "xyz-hub-tags")
+        unique = get_customProperty_str(qnode, "xyz-hub-id")
         name = qnode.name()
         meta = json.loads(meta)
         conn_info = json.loads(conn_info)

--- a/XYZHubConnector/modules/layer/layer_props.py
+++ b/XYZHubConnector/modules/layer/layer_props.py
@@ -32,16 +32,8 @@ class QProps():
         
     @classmethod
     def updatePropsVersion(cls,qnode):
-        # print(qnode.customProperties()
-        #     if hasattr(qnode, "customProperties")
-        #     else qnode.customPropertyKeys())
         for key in cls.v0.keys():
             cls._getOldProperty(qnode, key)
-        # print("after")
-        # print(qnode.customProperties()
-        #     if hasattr(qnode, "customProperties")
-        #     else qnode.customPropertyKeys())
-        # print()
 
     @classmethod
     def _getOldProperty(cls,qnode,key):

--- a/XYZHubConnector/modules/layer/layer_props.py
+++ b/XYZHubConnector/modules/layer/layer_props.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+# Copyright (c) 2019 HERE Europe B.V.
+#
+# SPDX-License-Identifier: MIT
+# License-Filename: LICENSE
+#
+###############################################################################
+
+class QProps():
+    LAYER_META = "XYZHub/meta"
+    UNIQUE_ID = "XYZHub/id"
+    CONN_INFO = "XYZHub/conn"
+    TAGS = "XYZHub/tags" # included in params
+    LOADER_PARAMS = "XYZHub/loader"
+    EDIT_FLAG = "XYZHub/edit"
+
+    v0 = {
+        LAYER_META : "xyz-hub",
+        UNIQUE_ID : "xyz-hub-id",
+        CONN_INFO : "xyz-hub-conn",
+        TAGS : "xyz-hub-tags",
+        LOADER_PARAMS : "xyz-hub-loader",
+        EDIT_FLAG : "xyz-hub-edit"
+    }
+    
+    @staticmethod
+    def getProperty(qnode,key):
+        val = qnode.customProperty(key)
+        return val
+        
+    @classmethod
+    def updatePropsVersion(cls,qnode):
+        # print(qnode.customProperties()
+        #     if hasattr(qnode, "customProperties")
+        #     else qnode.customPropertyKeys())
+        for key in cls.v0.keys():
+            cls._getOldProperty(qnode, key)
+        # print("after")
+        # print(qnode.customProperties()
+        #     if hasattr(qnode, "customProperties")
+        #     else qnode.customPropertyKeys())
+        # print()
+
+    @classmethod
+    def _getOldProperty(cls,qnode,key):
+        val = None
+        for version, backward_mapping in reversed(list(enumerate([
+            cls.v0, # v1, v2
+        ]))):
+            oldKey = backward_mapping[key]
+            oldValue = qnode.customProperty(oldKey)
+            if oldValue is None: continue
+
+            if val is None:
+                val = cls.translateValue(oldValue, version)
+                qnode.setCustomProperty(key, val)
+            qnode.removeCustomProperty(oldKey)
+
+        return val
+
+    @classmethod
+    def translateValue(cls, oldValue, version):
+        return oldValue

--- a/XYZHubConnector/modules/layer/layer_utils.py
+++ b/XYZHubConnector/modules/layer/layer_utils.py
@@ -15,7 +15,8 @@ from qgis.PyQt.QtCore import QVariant
 
 from ...models import SpaceConnectionInfo
 from ..controller import make_qt_args
-from . import parser, layer_props as QProps
+from . import parser
+from .layer_props import QProps
 
 
 def is_valid_json(txt):
@@ -24,6 +25,13 @@ def is_valid_json(txt):
     except ValueError as e:
         return False
     return True
+def load_json_none(txt):
+    obj = None
+    try:
+        obj = json.loads(txt)
+    except ValueError as e:
+        pass
+    return obj
 
 def get_feat_iter(vlayer):
     # assert isinstance(vlayer, QgsVectorLayer)
@@ -125,7 +133,7 @@ def update_feat_non_null(vlayer, ft):
 def get_layer(layer_id):
     return QgsProject.instance().mapLayer(layer_id)
 def get_customProperty_str(qnode, key):
-    return str(qnode.customProperty(key))
+    return str(QProps.getProperty(qnode,key))
 
 def get_conn_info_from_layer(layer_id):
     vlayer = get_layer(layer_id)
@@ -134,12 +142,17 @@ def get_conn_info_from_layer(layer_id):
     conn_info = json.loads(conn_info)
     conn_info = SpaceConnectionInfo.from_dict(conn_info)
     return conn_info
-    
+
+def updated_xyz_node(qnode):
+    QProps.updatePropsVersion(qnode)
+    return qnode
 def is_xyz_supported_node(qnode):
     meta = get_customProperty_str(qnode, QProps.LAYER_META)
     flag = isinstance(meta, str) and is_valid_json(meta)
+    # print( meta[:10], type(meta), flag)
     return flag
 def is_xyz_supported_layer(vlayer):
+    # print("layer", end=", ")
     return is_xyz_supported_node(vlayer)
 def iter_group_node(root):
     for g in root.findGroups():

--- a/XYZHubConnector/modules/layer/layer_utils.py
+++ b/XYZHubConnector/modules/layer/layer_utils.py
@@ -132,21 +132,14 @@ def get_conn_info_from_layer(layer_id):
     conn_info = SpaceConnectionInfo.from_dict(conn_info)
     return conn_info
     
-def is_root_node(qnode):
-    return qnode.parent() is None
 def is_xyz_supported_node(qnode):
     meta = get_customProperty_str(qnode, "xyz-hub")
     flag = isinstance(meta, str) and is_valid_json(meta)
     return flag
-def get_group_node(qnode):
-    p = qnode.parent()
-    a = qnode if p.parent() is None else get_group_node(p)
-    # print(a, qnode, p)
-    return a
-def is_xyz_supported_node_group(qnode):
-    if not qnode: return False
-    group = get_group_node(qnode)
-    return (is_xyz_supported_node(qnode) 
-        or is_xyz_supported_node(group))
 def is_xyz_supported_layer(vlayer):
     return is_xyz_supported_node(vlayer)
+def iter_group_node(root):
+    for g in root.findGroups():
+        yield g
+        for gg in iter_group_node(g):
+            yield gg

--- a/XYZHubConnector/modules/layer/layer_utils.py
+++ b/XYZHubConnector/modules/layer/layer_utils.py
@@ -121,10 +121,13 @@ def update_feat_non_null(vlayer, ft):
         vlayer.updateExtents()
 def get_layer(layer_id):
     return QgsProject.instance().mapLayer(layer_id)
+def get_customProperty_str(qnode, key):
+    return str(qnode.customProperty(key))
+
 def get_conn_info_from_layer(layer_id):
     vlayer = get_layer(layer_id)
     if vlayer is None: return
-    conn_info = vlayer.customProperty("xyz-hub-conn")
+    conn_info = get_customProperty_str(vlayer, "xyz-hub-conn")
     conn_info = json.loads(conn_info)
     conn_info = SpaceConnectionInfo.from_dict(conn_info)
     return conn_info
@@ -132,7 +135,7 @@ def get_conn_info_from_layer(layer_id):
 def is_root_node(qnode):
     return qnode.parent() is None
 def is_xyz_supported_node(qnode):
-    meta = qnode.customProperty("xyz-hub")
+    meta = get_customProperty_str(qnode, "xyz-hub")
     flag = isinstance(meta, str) and is_valid_json(meta)
     return flag
 def get_group_node(qnode):
@@ -140,7 +143,7 @@ def get_group_node(qnode):
     a = qnode if p.parent() is None else get_group_node(p)
     # print(a, qnode, p)
     return a
-def is_xyz_supported_node_recursive(qnode):
+def is_xyz_supported_node_group(qnode):
     if not qnode: return False
     group = get_group_node(qnode)
     return (is_xyz_supported_node(qnode) 

--- a/XYZHubConnector/modules/layer/layer_utils.py
+++ b/XYZHubConnector/modules/layer/layer_utils.py
@@ -149,10 +149,8 @@ def updated_xyz_node(qnode):
 def is_xyz_supported_node(qnode):
     meta = get_customProperty_str(qnode, QProps.LAYER_META)
     flag = isinstance(meta, str) and is_valid_json(meta)
-    # print( meta[:10], type(meta), flag)
     return flag
 def is_xyz_supported_layer(vlayer):
-    # print("layer", end=", ")
     return is_xyz_supported_node(vlayer)
 def iter_group_node(root):
     for g in root.findGroups():

--- a/XYZHubConnector/modules/layer/layer_utils.py
+++ b/XYZHubConnector/modules/layer/layer_utils.py
@@ -9,11 +9,14 @@
 ###############################################################################
 import json
 
-from ..controller import make_qt_args
-from ...models import SpaceConnectionInfo
-from . import parser
 from qgis.core import QgsFeatureRequest, QgsProject
 from qgis.PyQt.QtCore import QVariant
+
+
+from ...models import SpaceConnectionInfo
+from ..controller import make_qt_args
+from . import parser, layer_props as QProps
+
 
 def is_valid_json(txt):
     try:
@@ -127,13 +130,13 @@ def get_customProperty_str(qnode, key):
 def get_conn_info_from_layer(layer_id):
     vlayer = get_layer(layer_id)
     if vlayer is None: return
-    conn_info = get_customProperty_str(vlayer, "xyz-hub-conn")
+    conn_info = get_customProperty_str(vlayer, QProps.CONN_INFO)
     conn_info = json.loads(conn_info)
     conn_info = SpaceConnectionInfo.from_dict(conn_info)
     return conn_info
     
 def is_xyz_supported_node(qnode):
-    meta = get_customProperty_str(qnode, "xyz-hub")
+    meta = get_customProperty_str(qnode, QProps.LAYER_META)
     flag = isinstance(meta, str) and is_valid_json(meta)
     return flag
 def is_xyz_supported_layer(vlayer):

--- a/XYZHubConnector/plugin.py
+++ b/XYZHubConnector/plugin.py
@@ -36,7 +36,7 @@ from .modules.loader import (LoaderManager, EmptyXYZSpaceError, InitUploadLayerC
 from .modules.layer.edit_buffer import EditBuffer
 from .modules.layer import bbox_utils
 from .modules.layer.layer_utils import (is_xyz_supported_layer, get_feat_upload_from_iter,
-    is_xyz_supported_node, get_customProperty_str)
+    is_xyz_supported_node, get_customProperty_str, iter_group_node)
     
 from .modules.layer import tile_utils, XYZLayer
 
@@ -465,7 +465,7 @@ class XYZHubConnector(object):
             vl for vl in QgsProject.instance().layerTreeRoot().checkedLayers()
             if is_xyz_supported_layer(vl)
             ] + [
-            g for g in QgsProject.instance().layerTreeRoot().findGroups()
+            g for g in iter_group_node(QgsProject.instance().layerTreeRoot())
             if len(g.children()) == 0 and g.isVisible() 
             and is_xyz_supported_node(g)
         ]:
@@ -498,10 +498,10 @@ class XYZHubConnector(object):
 
     def init_tile_loader(self):
         cnt = 0
-        for qnode in [
-            g for g in QgsProject.instance().layerTreeRoot().findGroups()
+        for qnode in (
+            g for g in iter_group_node(QgsProject.instance().layerTreeRoot())
             if is_xyz_supported_node(g)
-        ]:
+        ):
             try: 
                 layer = XYZLayer.load_from_qnode(qnode)
                 con_load = TileLayerLoader(self.network, n_parallel=1, layer=layer)

--- a/XYZHubConnector/plugin.py
+++ b/XYZHubConnector/plugin.py
@@ -38,7 +38,7 @@ from .modules.layer import bbox_utils
 from .modules.layer.layer_utils import (is_xyz_supported_layer, get_feat_upload_from_iter,
     is_xyz_supported_node, get_customProperty_str, iter_group_node)
     
-from .modules.layer import tile_utils, XYZLayer
+from .modules.layer import tile_utils, XYZLayer, layer_props as QProps
 
 from .modules.network import NetManager, net_handler
 
@@ -469,7 +469,7 @@ class XYZHubConnector(object):
             if len(g.children()) == 0 and g.isVisible() 
             and is_xyz_supported_node(g)
         ]:
-            xlayer_id = get_customProperty_str(qnode, "xyz-hub-id")
+            xlayer_id = get_customProperty_str(qnode, QProps.UNIQUE_ID)
             con = self.con_man.get_from_xyz_layer(xlayer_id)
             if con is None: continue
             if con in unique_con: continue

--- a/XYZHubConnector/plugin.py
+++ b/XYZHubConnector/plugin.py
@@ -36,7 +36,7 @@ from .modules.loader import (LoaderManager, EmptyXYZSpaceError, InitUploadLayerC
 from .modules.layer.edit_buffer import EditBuffer
 from .modules.layer import bbox_utils
 from .modules.layer.layer_utils import (is_xyz_supported_layer, get_feat_upload_from_iter,
-    is_xyz_supported_node)
+    is_xyz_supported_node, get_customProperty_str)
     
 from .modules.layer import tile_utils, XYZLayer
 
@@ -469,7 +469,7 @@ class XYZHubConnector(object):
             if len(g.children()) == 0 and g.isVisible() 
             and is_xyz_supported_node(g)
         ]:
-            xlayer_id = qnode.customProperty("xyz-hub-id")
+            xlayer_id = get_customProperty_str(qnode, "xyz-hub-id")
             con = self.con_man.get_from_xyz_layer(xlayer_id)
             if con is None: continue
             if con in unique_con: continue


### PR DESCRIPTION
Tile loading layer continues to work after re-open a saved project or after re-enable plugin 
(optional: iterate loading layer)

+ Save xyz params into group/layer qgis properties
+ When open project, read these qgis properties and recreate components
