### PR TITLE
Auto-detect XYZ layer from project

### DIFF
--- a/XYZHubConnector/modules/layer/layer.py
+++ b/XYZHubConnector/modules/layer/layer.py
@@ -22,7 +22,7 @@ from qgis.PyQt.QtXml import QDomDocument
 
 from . import parser, render
 from .layer_props import QProps
-from .layer_utils import get_feat_cnt_from_src, get_customProperty_str, load_json_none
+from .layer_utils import get_feat_cnt_from_src, get_customProperty_str, load_json_default
 from ...models.space_model import parse_copyright
 from ...models import SpaceConnectionInfo
 from ...utils import make_unique_full_path, make_fixed_full_path
@@ -64,10 +64,10 @@ class XYZLayer(object):
         unique = get_customProperty_str(qnode, QProps.UNIQUE_ID)
         loader_params = get_customProperty_str(qnode, QProps.LOADER_PARAMS)
         name = qnode.name()
-        meta = json.loads(meta)
-        conn_info = json.loads(conn_info)
+        meta = load_json_default(meta, default=dict())
+        conn_info = load_json_default(conn_info, default=dict())
         conn_info = SpaceConnectionInfo.from_dict(conn_info)
-        loader_params = load_json_none(loader_params)
+        loader_params = load_json_default(loader_params, default=None)
 
         obj = cls(conn_info, meta, tags=tags, unique=unique, group_name=name, loader_params=loader_params)
         obj.qgroups["main"] = qnode

--- a/XYZHubConnector/modules/layer/layer_utils.py
+++ b/XYZHubConnector/modules/layer/layer_utils.py
@@ -25,8 +25,8 @@ def is_valid_json(txt):
     except ValueError as e:
         return False
     return True
-def load_json_none(txt):
-    obj = None
+def load_json_default(txt, default=None):
+    obj = default
     try:
         obj = json.loads(txt)
     except ValueError as e:

--- a/XYZHubConnector/plugin.py
+++ b/XYZHubConnector/plugin.py
@@ -471,7 +471,7 @@ class XYZHubConnector(object):
             if is_xyz_supported_layer(vl)
             ] + [
             g for g in iter_group_node(QgsProject.instance().layerTreeRoot())
-            if len(g.children()) == 0 and g.isVisible() 
+            if len(g.findLayers()) == 0 and g.isVisible() 
             and is_xyz_supported_node(g)
         ]:
             xlayer_id = get_customProperty_str(qnode, QProps.UNIQUE_ID)


### PR DESCRIPTION
Auto detect XYZ layer after re-open a saved project or after re-enable plugin 
(tile loading layer should continue to work #21)

+ Valid XYZ layers are:
  + Group nodes
  + Nested group nodes
+ Invalid XYZ layers are:
  + Orphan layers (reloading them might require creating new layer)

This PR includes related bug fixes