### PR TITLE
Ensure fields to be consistent after editing

### DIFF
--- a/XYZHubConnector/plugin.py
+++ b/XYZHubConnector/plugin.py
@@ -20,6 +20,7 @@ from . import config
 
 from .gui.space_dialog import MainDialog
 from .gui.util_dialog import ConfirmDialog, exec_warning_dialog
+from .xyz_qgis.common.utils import disconnect_silent
 
 from .xyz_qgis.models import (
     LOADING_MODES,
@@ -275,9 +276,10 @@ class XYZHubConnector(object):
 
     def unload_modules(self):
         # self.con_man.disconnect_ux( self.iface)
-        QgsProject.instance().cleared.disconnect(self.new_session)
-        QgsProject.instance().layersWillBeRemoved["QStringList"].disconnect(
-            self.edit_buffer.remove_layers
+        disconnect_silent(QgsProject.instance().cleared, self.new_session)
+        disconnect_silent(
+            QgsProject.instance().layersWillBeRemoved["QStringList"],
+            self.edit_buffer.remove_layers,
         )
         # QgsProject.instance().layersWillBeRemoved["QStringList"].disconnect(
         # self.layer_man.remove_layers)
@@ -291,15 +293,17 @@ class XYZHubConnector(object):
 
         self.iface.mapCanvas().extentsChanged.disconnect(self.reload_tile)
 
-        QgsProject.instance().layerTreeRoot().willRemoveChildren.disconnect(
-            self.cb_qnodes_deleting
+        disconnect_silent(
+            QgsProject.instance().layerTreeRoot().willRemoveChildren, self.cb_qnodes_deleting
         )
-        QgsProject.instance().layerTreeRoot().removedChildren.disconnect(self.cb_qnodes_deleted)
-        QgsProject.instance().layerTreeRoot().visibilityChanged.disconnect(
-            self.cb_qnode_visibility_changed
+        disconnect_silent(
+            QgsProject.instance().layerTreeRoot().removedChildren, self.cb_qnodes_deleted
         )
-
-        QgsProject.instance().readProject.disconnect(self.import_project)
+        disconnect_silent(
+            QgsProject.instance().layerTreeRoot().visibilityChanged,
+            self.cb_qnode_visibility_changed,
+        )
+        disconnect_silent(QgsProject.instance().readProject, self.import_project)
 
         # utils.disconnect_silent(self.iface.currentLayerChanged)
 

--- a/XYZHubConnector/xyz_qgis/common/utils.py
+++ b/XYZHubConnector/xyz_qgis/common/utils.py
@@ -21,10 +21,13 @@ def get_current_millis_time():
     return int(round(time.time() * 1000))
 
 
-def disconnect_silent(signal):
+def disconnect_silent(signal, fn=None):
     ok = True
     try:
-        signal.disconnect()
+        if fn is None:
+            signal.disconnect()
+        else:
+            signal.disconnect(fn)
     except TypeError:
         ok = False
     return ok

--- a/XYZHubConnector/xyz_qgis/layer/edit_buffer.py
+++ b/XYZHubConnector/xyz_qgis/layer/edit_buffer.py
@@ -276,7 +276,7 @@ class LayeredEditBuffer(object):
 
     def update_synced_feat(self, fid, feat):
         vlayer = get_layer(self.layer_id)
-        fields = vlayer.fields()
+        fields = vlayer.dataProvider().fields()
         ft = parser.xyz_json_to_feat(feat, fields)
         ft.setId(fid)
         update_feat_non_null(vlayer, ft)

--- a/XYZHubConnector/xyz_qgis/layer/edit_buffer.py
+++ b/XYZHubConnector/xyz_qgis/layer/edit_buffer.py
@@ -22,6 +22,7 @@ from .layer_utils import (
     get_conn_info_from_layer,
     get_layer,
 )
+from ..common.utils import disconnect_silent
 
 from ..common.signal import make_print_qgis
 
@@ -426,7 +427,7 @@ class LayeredEditBuffer(object):
 
     def unload_connection(self):
         for signal, callback in self.callback_pairs:
-            signal.disconnect(callback)
+            disconnect_silent(signal, callback)
 
 
 class EditBuffer(object):

--- a/XYZHubConnector/xyz_qgis/layer/layer.py
+++ b/XYZHubConnector/xyz_qgis/layer/layer.py
@@ -23,6 +23,7 @@ from qgis.core import (
     QgsVectorLayer,
     QgsCoordinateTransform,
     QgsWkbTypes,
+    QgsFields,
 )
 
 from qgis.utils import iface
@@ -437,6 +438,7 @@ class XYZLayer(object):
     def _remove_layer(self, geom_str, idx):
         """Remove vlayer from the internal map without messing the index"""
         self.map_vlayer[geom_str][idx] = None
+        self.map_fields[geom_str][idx] = QgsFields()
 
     def _init_ext_layer(self, geom_str, idx, crs):
         """given non map of feat, init a qgis layer

--- a/XYZHubConnector/xyz_qgis/layer/layer.py
+++ b/XYZHubConnector/xyz_qgis/layer/layer.py
@@ -442,6 +442,13 @@ class XYZLayer(object):
         self.map_vlayer[geom_str][idx] = None
         self.map_fields[geom_str][idx] = parser.new_fields_gpkg()
 
+    def refresh_map_fields(self):
+        for geom_str in self.map_vlayer:
+            for idx, vlayer in enumerate(self.map_vlayer.get(geom_str, list())):
+                if vlayer is None:
+                    continue
+                self.map_fields[geom_str][idx] = vlayer.dataProvider().fields()
+
     def _init_ext_layer(self, geom_str, idx, crs):
         """given non map of feat, init a qgis layer
         :map_feat: {geom_string: list_of_feat}

--- a/XYZHubConnector/xyz_qgis/layer/layer.py
+++ b/XYZHubConnector/xyz_qgis/layer/layer.py
@@ -107,7 +107,7 @@ class XYZLayer(object):
             vlayer = i.layer()
             geom_str = QgsWkbTypes.displayString(vlayer.wkbType())
             obj.map_vlayer.setdefault(geom_str, list()).append(vlayer)
-            obj.map_fields.setdefault(geom_str, list()).append(vlayer.fields())
+            obj.map_fields.setdefault(geom_str, list()).append(vlayer.dataProvider().fields())
             # obj._save_meta_vlayer(vlayer)
         return obj
 
@@ -438,7 +438,7 @@ class XYZLayer(object):
     def _remove_layer(self, geom_str, idx):
         """Remove vlayer from the internal map without messing the index"""
         self.map_vlayer[geom_str][idx] = None
-        self.map_fields[geom_str][idx] = QgsFields()
+        self.map_fields[geom_str][idx] = parser.new_fields_gpkg()
 
     def _init_ext_layer(self, geom_str, idx, crs):
         """given non map of feat, init a qgis layer

--- a/XYZHubConnector/xyz_qgis/layer/layer.py
+++ b/XYZHubConnector/xyz_qgis/layer/layer.py
@@ -26,10 +26,9 @@ from qgis.core import (
 )
 
 from qgis.utils import iface
-from qgis.PyQt.QtCore import QObject, pyqtSignal
 from qgis.PyQt.QtXml import QDomDocument
 
-from . import parser, render
+from . import parser
 from .layer_props import QProps
 from .layer_utils import get_feat_cnt_from_src, get_customProperty_str, load_json_default
 from ..models import SpaceConnectionInfo, parse_copyright
@@ -395,7 +394,9 @@ class XYZLayer(object):
         qgroups: dict["main"] = group
             dict[geom] = list([vlayer1, vlayer2,...])
         map_vlayer: dict[geom_str] = list([vlayer1, vlayer2,...])
+            vlayer order in list shall always be fixed, deleted vlayer hall be set to None
         map_fields: dict[geom_str] = list([fields1, fields2,...])
+            fields order in list shall always be fixed and not be deleted
         geom_str: QgsWkbTypes.displayString (detailed geometry, e.g. Multi-)
         geom: QgsWkbTypes.geometryDisplayString (generic geometry,)
         """

--- a/XYZHubConnector/xyz_qgis/layer/layer.py
+++ b/XYZHubConnector/xyz_qgis/layer/layer.py
@@ -105,6 +105,8 @@ class XYZLayer(object):
         # obj._save_meta_node(qnode)
         for i in qnode.findLayers():
             vlayer = i.layer()
+            if not vlayer.isValid():
+                continue
             geom_str = QgsWkbTypes.displayString(vlayer.wkbType())
             obj.map_vlayer.setdefault(geom_str, list()).append(vlayer)
             obj.map_fields.setdefault(geom_str, list()).append(vlayer.dataProvider().fields())

--- a/XYZHubConnector/xyz_qgis/layer/layer.py
+++ b/XYZHubConnector/xyz_qgis/layer/layer.py
@@ -435,8 +435,7 @@ class XYZLayer(object):
 
     def _remove_layer(self, geom_str, idx):
         """Remove vlayer from the internal map without messing the index"""
-        self.map_vlayer[geom_str].pop(idx)
-        self.map_fields[geom_str].pop(idx)
+        self.map_vlayer[geom_str][idx] = None
 
     def _init_ext_layer(self, geom_str, idx, crs):
         """given non map of feat, init a qgis layer

--- a/XYZHubConnector/xyz_qgis/layer/parser.py
+++ b/XYZHubConnector/xyz_qgis/layer/parser.py
@@ -360,7 +360,7 @@ def xyz_json_to_feat(feat_json, fields):
     Convert xyz geojson to feature, given fields
     """
 
-    names = fields.names()
+    names = set(fields.names())
 
     qattrs = list()
 
@@ -427,19 +427,24 @@ def prepare_fields(feat_json, lst_fields, threshold=0.8):
             props_names,
         )
         if fields.size() > 1
-        else threshold
+        else -1
         for fields in lst_fields
     ]
     idx, score = max(enumerate(lst_score), key=lambda x: x[1], default=[0, 0])
+    idx_min, score_min = min(enumerate(lst_score), key=lambda x: x[1], default=[0, 0])
 
     if score < threshold or not idx < len(lst_fields):  # new fields
-        idx = len(lst_fields)
-        fields = new_fields_gpkg()
-        lst_fields.append(fields)
-        # print("len prop", len(props_names), "score", lst_score, "lst_fields", len(lst_fields))
-        # print("len fields", [f.size() for f in lst_fields])
+        if score_min >= 0:  # new fields
+            idx = len(lst_fields)
+            fields = new_fields_gpkg()
+            lst_fields.append(fields)
+        else:  # select empty fields
+            idx = idx_min
+            fields = lst_fields[idx]
     else:
         fields = lst_fields[idx]
+    # print("len prop", len(props_names), idx, "score", lst_score, "lst_fields", len(lst_fields))
+    # print("len fields", [f.size() for f in lst_fields])
 
     return fields, idx
 

--- a/XYZHubConnector/xyz_qgis/layer/parser.py
+++ b/XYZHubConnector/xyz_qgis/layer/parser.py
@@ -147,6 +147,10 @@ def non_expression_fields(fields):
     return [f for i, f in enumerate(fields) if fields.fieldOrigin(i) != fields.OriginExpression]
 
 
+def check_non_expression_fields(fields):
+    return all(fields.fieldOrigin(i) != fields.OriginExpression for i, f in enumerate(fields))
+
+
 def feature_to_xyz_json(features, is_new=False, ignore_null=True):
     def _xyz_props(props, ignore_keys=tuple()):
         # for all key start with @ (internal): str to dict (disabled)

--- a/XYZHubConnector/xyz_qgis/layer/parser.py
+++ b/XYZHubConnector/xyz_qgis/layer/parser.py
@@ -382,7 +382,7 @@ def xyz_json_to_feat(feat_json, fields):
                         val.convert(cast)
                         break
             if not val.type() in valid_qvariant:
-                print_qgis("Invalid type", k, val.typeName())
+                print_qgis("Field '%s': Invalid type: %s. Value: %s" % (k, val.typeName(), val))
                 continue
             if k not in names:
                 fields.append(make_field(k, val))
@@ -417,7 +417,16 @@ def prepare_fields(feat_json, lst_fields, threshold=0.8):
         rename_special_props(props)  # rename fid in props
         props_names = [k for k, v in props.items() if v is not None]
     lst_score = [
-        fields_similarity((fields.names()), orig_props_names, props_names) for fields in lst_fields
+        fields_similarity(
+            [
+                f.name()
+                for i, f in enumerate(fields)
+                if fields.fieldOrigin(i) != fields.OriginExpression
+            ],
+            orig_props_names,
+            props_names,
+        )
+        for fields in lst_fields
     ]
     idx, score = max(enumerate(lst_score), key=lambda x: x[1], default=[0, 0])
 

--- a/XYZHubConnector/xyz_qgis/layer/parser.py
+++ b/XYZHubConnector/xyz_qgis/layer/parser.py
@@ -426,7 +426,7 @@ def prepare_fields(feat_json, lst_fields, threshold=0.8):
             orig_props_names,
             props_names,
         )
-        if fields.size()
+        if fields.size() > 1
         else threshold
         for fields in lst_fields
     ]

--- a/XYZHubConnector/xyz_qgis/layer/render.py
+++ b/XYZHubConnector/xyz_qgis/layer/render.py
@@ -103,8 +103,9 @@ def add_feature_render(vlayer, feat, new_fields):
     if transformer.isValid() and not transformer.isShortCircuited():
         feat = filter(None, (parser.transform_geom(ft, transformer) for ft in feat if ft))
 
-    names = set(vlayer.fields().names())
-    diff_fields = [f for f in parser.non_expression_fields(new_fields) if f.name() not in names]
+    names = set(pr.fields().names())
+    assert parser.check_non_expression_fields(new_fields)
+    diff_fields = [f for f in new_fields if not f.name() in names]
 
     # print_qgis(len(names), names)
     # print_qgis(len(new_fields), new_fields.names())

--- a/XYZHubConnector/xyz_qgis/layer/render.py
+++ b/XYZHubConnector/xyz_qgis/layer/render.py
@@ -120,6 +120,10 @@ def add_feature_render(vlayer, feat, new_fields):
     pr.addAttributes(diff_fields)
     vlayer.updateFields()
 
+    # update feature fields according to provider fields
+    if not parser.check_same_fields(new_fields, pr.fields()):
+        feat = filter(None, (parser.update_feature_fields(ft, pr.fields()) for ft in feat if ft))
+
     ok, out_feat = pr.addFeatures(feat)
     vlayer.updateExtents()  # will hide default progress bar
     # post_render(vlayer) # disable in order to keep default progress bar running

--- a/XYZHubConnector/xyz_qgis/layer/render.py
+++ b/XYZHubConnector/xyz_qgis/layer/render.py
@@ -104,7 +104,7 @@ def add_feature_render(vlayer, feat, new_fields):
         feat = filter(None, (parser.transform_geom(ft, transformer) for ft in feat if ft))
 
     names = set(vlayer.fields().names())
-    diff_fields = [f for f in new_fields if not f.name() in names]
+    diff_fields = [f for f in parser.non_expression_fields(new_fields) if f.name() not in names]
 
     # print_qgis(len(names), names)
     # print_qgis(len(new_fields), new_fields.names())

--- a/XYZHubConnector/xyz_qgis/loader/layer_loader.py
+++ b/XYZHubConnector/xyz_qgis/loader/layer_loader.py
@@ -171,6 +171,7 @@ class LoadLayerController(BaseLoader):
 
     def _run(self):
         conn_info = self.get_conn_info()
+        self.layer.refresh_map_fields()  # ensure map fields is updated from provider
 
         # TODO refactor methods
         if not self.params_queue.has_next():

--- a/test/load_point_layer.py
+++ b/test/load_point_layer.py
@@ -23,7 +23,7 @@ from XYZHubConnector.xyz_qgis.models.connection import SpaceConnectionInfo
 app = start_app()
 
 
-class Counter():
+class Counter:
     def __init__(self, total, callback):
         self.cnt = 0
         self.total = total
@@ -38,7 +38,7 @@ class Counter():
 
 
 def get_row_col_bounds_here(level):
-    """ 
+    """
     [x,y] or [col, row], start from bottom left, go anti-clockwise
     level 0: 0,0
     level 1: 0,0; 1,0
@@ -50,7 +50,7 @@ def get_row_col_bounds_here(level):
 
 
 def get_row_col_bounds_web(level):
-    """ 
+    """
     coord [x,y]
     """
     nrow = 2 ** (level) if level else 1
@@ -59,7 +59,7 @@ def get_row_col_bounds_web(level):
 
 
 def get_row_col_bounds_tms(level):
-    """ 
+    """
     coord [x,y]
     """
     nrow = 2 ** (level) if level else 1
@@ -77,10 +77,7 @@ def generate_tile(level, schema="web"):
         nrow, ncol = get_row_col_bounds_tms(level)  # missing coord y=-90
     else:
         nrow, ncol = get_row_col_bounds_here(level)
-    lst = [
-        "%s_%s_%s" % (level, c, r)
-        for r in range(nrow) for c in range(ncol)
-    ]
+    lst = ["%s_%s_%s" % (level, c, r) for r in range(nrow) for c in range(ncol)]
     # lst = ["0_0_0","0_0_1","0_0_2","0_0_3","0_0_4","0_0_5","0_0_6","0_0_100"] # tms
     # lst = ["1_1_1","1_0_1","1_1_0","1_0_0"] # + lst
     # lst += ["2_1_2"]
@@ -96,30 +93,24 @@ def make_tuple_coord(level):
     return set(tuple(coord) for coord in make_coord(level))
 
 
-class Validator():
+class Validator:
     def __init__(self, level):
         self.level = level
         self.cnt_x = (180 * 2) // step_from_level(level) + 1
         lst_coord = make_tuple_coord(level)
-        self.expected = dict(
-            cnt=len(lst_coord),
-            lst_coord=set(lst_coord)
-        )
+        self.expected = dict(cnt=len(lst_coord), lst_coord=set(lst_coord))
         self.actual = dict(cnt=0, lst_coord=list())
 
     def check_cnt(self, cnt):
         print("feat per tile", cnt)
         actual, expected = self._get_case("cnt", cnt)
-        print(actual, expected, actual == expected,
-              "cnt")
+        print(actual, expected, actual == expected, "cnt")
 
     def check_coord(self, lst_coord):
         actual_, expected = self._get_case("lst_coord", lst_coord)
         actual = set(actual_)
-        print(len(actual_), len(actual), len(actual_) - len(actual),
-              "overlap")
-        print(len(actual), len(expected), len(actual) == len(expected),
-              "unique")
+        print(len(actual_), len(actual), len(actual_) - len(actual), "overlap")
+        print(len(actual), len(expected), len(actual) == len(expected), "unique")
         print("len y=-90", self.cnt_x)
         actual_ = sorted(actual_)
         print("actual", actual_[:1], actual_[-1:])
@@ -149,16 +140,12 @@ class BoundedValidator(Validator):
         step = step_from_level(level)
         step = 1
         x_min, y_min, x_max, y_max = map(
-            lambda x: int(x) + (0 if int(x) > x else 1),
-            [x_min, y_min, x_max, y_max])
-        lst_coord = [(lon, lat)
-                     for lon in range(x_min, x_max, step)
-                     for lat in range(y_min, y_max, step)
-                     ]
-        self.expected = dict(
-            cnt=len(lst_coord),
-            lst_coord=set(lst_coord)
+            lambda x: int(x) + (0 if int(x) > x else 1), [x_min, y_min, x_max, y_max]
         )
+        lst_coord = [
+            (lon, lat) for lon in range(x_min, x_max, step) for lat in range(y_min, y_max, step)
+        ]
+        self.expected = dict(cnt=len(lst_coord), lst_coord=set(lst_coord))
 
 
 if __name__ == "__main__":
@@ -172,14 +159,14 @@ if __name__ == "__main__":
 
     # # all
     # tags = "%s-%s"%("point",level)
-    # rect = [-180, -90, 180, 90] 
+    # rect = [-180, -90, 180, 90]
     # lst_tiles = generate_tile(level, tile_schema)
     # print(lst_tiles)
     # validator = Validator(level)
 
     # bounded
     tags = "point"
-    # rect = [-180, -90, -165, -65] 
+    # rect = [-180, -90, -165, -65]
     # rect = [-136.7, -61.5, -92.9, -34.0]  # level 5
     rect = [-136.9, -61.5, -130.9, -55.5]  # level 9
     # higher level require moore precise coord
@@ -189,8 +176,7 @@ if __name__ == "__main__":
     validator = BoundedValidator(level, *rect)
 
     lst_params = [
-        dict(tile_schema=tile_schema, tile_id=t, limit=100000, tags=tags)
-        for t in lst_tiles
+        dict(tile_schema=tile_schema, tile_id=t, limit=100000, tags=tags) for t in lst_tiles
     ]
     total = len(lst_tiles)
 

--- a/test/make_point_layer.py
+++ b/test/make_point_layer.py
@@ -25,10 +25,7 @@ app = start_app()
 
 
 def make_point_feat(coord):
-    return {
-        "type": "Feature",
-        "geometry": {"type": "Point", "coordinates": list(coord)}
-    }
+    return {"type": "Feature", "geometry": {"type": "Point", "coordinates": list(coord)}}
 
 
 def get_idx(lon, lat):
@@ -37,9 +34,11 @@ def get_idx(lon, lat):
 
 
 def iter_lon_lat(range_lon=(-180, 180), range_lat=(-90, 90), step=1):
-    return [(lon, lat)
-            for lon in range(range_lon[0], range_lon[1] + 1, step)
-            for lat in range(range_lat[0], range_lat[1] + 1, step)]
+    return [
+        (lon, lat)
+        for lon in range(range_lon[0], range_lon[1] + 1, step)
+        for lat in range(range_lat[0], range_lat[1] + 1, step)
+    ]
 
 
 def step_from_level(level):
@@ -61,17 +60,12 @@ def precompute_tags():
 def format_tags(tags, prefix=None):
     s = ",".join(str(t) for t in tags)
     if prefix:
-        s = ",".join([s,
-                      prefix,
-                      ",".join("%s-%s" % (prefix, t) for t in tags)
-                      ])
+        s = ",".join([s, prefix, ",".join("%s-%s" % (prefix, t) for t in tags)])
     return s
 
 
 def make_point_json(lst_tags):
-    obj = {
-        "type": "FeatureCollection"
-    }
+    obj = {"type": "FeatureCollection"}
     d = dict()
     lst_coord = list(iter_lon_lat())
     print("len coord/feat", len(lst_coord))
@@ -79,11 +73,11 @@ def make_point_json(lst_tags):
         d.setdefault(tags, list()).append(feat)
 
     return dict(
-        (tags, parser.make_lst_feature_collection(features))
-        for tags, features in d.items())
+        (tags, parser.make_lst_feature_collection(features)) for tags, features in d.items()
+    )
 
 
-class Counter():
+class Counter:
     cnt = 0
 
 
@@ -105,10 +99,7 @@ def make_point_features():
     # by generate tags for all levels
     # smallest step for coord currently is 1 (can be smaller)
 
-    lst_tags = [
-        format_tags(t, prefix="point")
-        for t in precompute_tags()
-    ]
+    lst_tags = [format_tags(t, prefix="point") for t in precompute_tags()]
     # print(lst_tags)
     print("len tags", len(lst_tags))
     tags_lst_obj = make_point_json(lst_tags)

--- a/test/mock_iface.py
+++ b/test/mock_iface.py
@@ -14,12 +14,16 @@ from qgis.core import QgsCoordinateReferenceSystem
 from qgis.PyQt.QtWidgets import QMainWindow
 from qgis.PyQt.QtCore import pyqtSignal
 
+
 class MyCanvas(QgsMapCanvas):
     closed = pyqtSignal()
-    def closeEvent(self,event):
+
+    def closeEvent(self, event):
         super().closeEvent(event)
         print("closing")
         self.closed.emit()
+
+
 # /python/testing/mocked.py
 def make_iface_canvas(test_async):
     my_iface = mock.Mock(spec=QgisInterface)
@@ -31,9 +35,10 @@ def make_iface_canvas(test_async):
     canvas.setFrameStyle(0)
     canvas.resize(400, 400)
     canvas.closed.connect(test_async._stop_async)
-    
+
     my_iface.mapCanvas.return_value = canvas
     return my_iface
+
 
 def canvas_zoom_to_layer(canvas, layer):
     layer.setCrs(canvas.mapSettings().destinationCrs())
@@ -45,6 +50,8 @@ def canvas_zoom_to_layer(canvas, layer):
     else:
         canvas.refresh()
     # canvas.waitWhileRendering()
+
+
 def show_canvas(iface):
     canvas = iface.mapCanvas()
     canvas.show()

--- a/test/test_basemap.py
+++ b/test/test_basemap.py
@@ -9,8 +9,7 @@
 ###############################################################################
 
 from test import mock_iface
-from test.utils import (BaseTestAsync, BaseTestWorkerAsync, add_test_fn_params,
-                        get_env)
+from test.utils import BaseTestAsync, BaseTestWorkerAsync, add_test_fn_params, get_env
 
 from qgis.testing import start_app, unittest
 
@@ -19,37 +18,38 @@ from XYZHubConnector.xyz_qgis import basemap
 
 import os
 
-APP_ID=os.environ["APP_ID"]
-APP_CODE=os.environ["APP_CODE"]
+APP_ID = os.environ["APP_ID"]
+APP_CODE = os.environ["APP_CODE"]
 
 app = start_app()
+
 
 class TestBasemap(BaseTestWorkerAsync):
     def test_basemap(self):
         iface = mock_iface.make_iface_canvas(self)
-        
+
         d = os.path.dirname(basemap.__file__)
-        t = basemap.load_xml(os.path.join(d,"basemap.xml"))
+        t = basemap.load_xml(os.path.join(d, "basemap.xml"))
         lst = list(t.values())
 
-        for k,v in t.items():
+        for k, v in t.items():
             canvas = mock_iface.show_canvas(iface)
             canvas.setWindowTitle(k)
 
-            basemap.add_auth(v,app_id=APP_ID, app_code=APP_CODE)
+            basemap.add_auth(v, app_id=APP_ID, app_code=APP_CODE)
             u = basemap.parse_uri(v)
-            self._log_debug(k,u)
-            layer = QgsRasterLayer( u, k, "wms")
+            self._log_debug(k, u)
+            layer = QgsRasterLayer(u, k, "wms")
 
             # QgsProject.instance().addMapLayer(layer)
             canvas.setLayers([layer])
             mock_iface.canvas_zoom_to_layer(canvas, layer)
-        
+
             self._wait_async()
+
+
 if __name__ == "__main__":
-    
+
     # unittest.main()
-    tests = [
-        "TestBasemap.test_basemap"
-    ]
-    unittest.main(defaultTest = tests)
+    tests = ["TestBasemap.test_basemap"]
+    unittest.main(defaultTest=tests)

--- a/test/test_fields_similarity.py
+++ b/test/test_fields_similarity.py
@@ -11,7 +11,7 @@ import json
 import random
 import numpy as np
 
-from test.utils import (BaseTestAsync, format_long_args)
+from test.utils import BaseTestAsync, format_long_args
 
 from qgis.core import QgsFields
 from qgis.testing import unittest
@@ -25,29 +25,30 @@ class TestFieldsSimilarity(BaseTestAsync):
         props = dict((v, k) for k, v in enumerate(props_keys))
 
         # from parser.prepare_fields
-        orig_props_names = [k for k, v in props.items() 
-            if v is not None] 
-        parser.rename_special_props(props) # rename fid in props
-        props_names = [k for k, v in props.items() 
-            if v is not None] 
+        orig_props_names = [k for k, v in props.items() if v is not None]
+        parser.rename_special_props(props)  # rename fid in props
+        props_names = [k for k, v in props.items() if v is not None]
 
         return parser.fields_similarity(fields_names, orig_props_names, props_names)
+
     def subtest_similarity_score(self, fields_names, props_keys, expected):
-        with self.subTest(fields_names=fields_names,props_keys=props_keys):
+        with self.subTest(fields_names=fields_names, props_keys=props_keys):
             score = self._similarity_of_fields_names_and_props_keys(fields_names, props_keys)
             self._log_debug("score", score)
             self.assertEqual(score, expected)
             return score
+
     def test_simple(self):
         fid = parser.QGS_ID
         xid = parser.QGS_XYZ_ID
         xyz_special_key = "@ns:com:here:xyz"
         score = self.subtest_similarity_score([fid, "a", "b"], ["a", "b"], 1)
-        score = self.subtest_similarity_score([fid,"a"], ["a","b"], 1)
-        score = self.subtest_similarity_score([fid,"a"], ["b"], 0)
-        score = self.subtest_similarity_score([fid,"a","c"], ["a","b"], 0.5)
-        score = self.subtest_similarity_score([fid, xyz_special_key,"a","b","c"], 
-            [xyz_special_key,"a"], 1)
+        score = self.subtest_similarity_score([fid, "a"], ["a", "b"], 1)
+        score = self.subtest_similarity_score([fid, "a"], ["b"], 0)
+        score = self.subtest_similarity_score([fid, "a", "c"], ["a", "b"], 0.5)
+        score = self.subtest_similarity_score(
+            [fid, xyz_special_key, "a", "b", "c"], [xyz_special_key, "a"], 1
+        )
 
     def test_empty(self):
         fid = parser.QGS_ID
@@ -55,11 +56,11 @@ class TestFieldsSimilarity(BaseTestAsync):
         xyz_special_key = "@ns:com:here:xyz"
         # empty fields, shall returns merge fields (score 1)
         score = self.subtest_similarity_score([fid], [], 1)
-        score = self.subtest_similarity_score([], [], 1) 
-        score = self.subtest_similarity_score([xyz_special_key], [], 1) 
-        score = self.subtest_similarity_score([xyz_special_key], [xyz_special_key], 1) 
-        score = self.subtest_similarity_score([fid, xyz_special_key], [], 1) 
-        score = self.subtest_similarity_score([fid, xyz_special_key], [xyz_special_key], 1) 
+        score = self.subtest_similarity_score([], [], 1)
+        score = self.subtest_similarity_score([xyz_special_key], [], 1)
+        score = self.subtest_similarity_score([xyz_special_key], [xyz_special_key], 1)
+        score = self.subtest_similarity_score([fid, xyz_special_key], [], 1)
+        score = self.subtest_similarity_score([fid, xyz_special_key], [xyz_special_key], 1)
         score = self.subtest_similarity_score([fid], [], 1)
         score = self.subtest_similarity_score([fid], [xyz_special_key], 1)
 
@@ -72,9 +73,9 @@ class TestFieldsSimilarity(BaseTestAsync):
         # empty fields will be merged with any props
         # merge if empty fields OR empty props
 
-        score = self.subtest_similarity_score([fid], ["a"], 1) 
-        score = self.subtest_similarity_score([fid,"a"], [], 1) 
-        score = self.subtest_similarity_score([fid,xyz_special_key], ["a",xyz_special_key], 1) 
+        score = self.subtest_similarity_score([fid], ["a"], 1)
+        score = self.subtest_similarity_score([fid, "a"], [], 1)
+        score = self.subtest_similarity_score([fid, xyz_special_key], ["a", xyz_special_key], 1)
         score = self.subtest_similarity_score([fid], [fid], 1)
         score = self.subtest_similarity_score([fid, xyz_special_key], [fid], 1)
 
@@ -86,11 +87,11 @@ class TestFieldsSimilarity(BaseTestAsync):
         # special keys are excluded when calculating similarity score
         # create new fields if either fields or props is not empty (score 0)
         # merge if empty fields AND empty props (score 1)
-        
+
         # fields or props not empty
         score = self.subtest_similarity_score([fid], ["a"], 0)
         score = self.subtest_similarity_score([fid, "a"], [], 0)
-        score = self.subtest_similarity_score([fid, xyz_special_key], ["a",xyz_special_key], 0)
+        score = self.subtest_similarity_score([fid, xyz_special_key], ["a", xyz_special_key], 0)
 
         # fields and props empty
         score = self.subtest_similarity_score([fid], [], 1)
@@ -99,10 +100,14 @@ class TestFieldsSimilarity(BaseTestAsync):
         score = self.subtest_similarity_score([fid, xid], [xyz_special_key], 1)
         score = self.subtest_similarity_score([fid, xyz_special_key], [xyz_special_key], 1)
         score = self.subtest_similarity_score([fid, xid, xyz_special_key], [xyz_special_key], 1)
-        
+
         # fields and props share common prop
-        score = self.subtest_similarity_score([fid, xyz_special_key, "a"], [xyz_special_key, "a"], 1)
-        score = self.subtest_similarity_score([fid, xid, xyz_special_key, "a"], [xyz_special_key, "a"], 1)
+        score = self.subtest_similarity_score(
+            [fid, xyz_special_key, "a"], [xyz_special_key, "a"], 1
+        )
+        score = self.subtest_similarity_score(
+            [fid, xid, xyz_special_key, "a"], [xyz_special_key, "a"], 1
+        )
 
         # special key in props will be renamed, thus not excluded
         score = self.subtest_similarity_score([fid], [fid], 0)
@@ -121,18 +126,39 @@ class TestFieldsSimilarity(BaseTestAsync):
         xyz_special_key = "@ns:com:here:xyz"
 
         score = self.subtest_similarity_score([fid, xid, parser.unique_field_name(fid)], [fid], 1)
-        score = self.subtest_similarity_score([fid, xid, parser.unique_field_name(fid.upper())], [fid.upper()], 1)
-        score = self.subtest_similarity_score([parser.unique_field_name(fid.upper())], [fid.upper()], 1)
-        score = self.subtest_similarity_score([fid, xid, xyz_special_key, parser.unique_field_name(fid.upper())], [xyz_special_key, fid.upper()], 1)
-        score = self.subtest_similarity_score([fid, xid, xyz_special_key, parser.unique_field_name(xid.upper())], [xyz_special_key, xid.upper()], 1)
-        score = self.subtest_similarity_score([fid, xid, xyz_special_key, parser.unique_field_name(fid), "a"], [xyz_special_key, fid, "a"], 1)
-        score = self.subtest_similarity_score([fid, xid, xyz_special_key, parser.unique_field_name(fid), "a"], [xyz_special_key, fid.upper(), "a"], 1/2)
+        score = self.subtest_similarity_score(
+            [fid, xid, parser.unique_field_name(fid.upper())], [fid.upper()], 1
+        )
+        score = self.subtest_similarity_score(
+            [parser.unique_field_name(fid.upper())], [fid.upper()], 1
+        )
+        score = self.subtest_similarity_score(
+            [fid, xid, xyz_special_key, parser.unique_field_name(fid.upper())],
+            [xyz_special_key, fid.upper()],
+            1,
+        )
+        score = self.subtest_similarity_score(
+            [fid, xid, xyz_special_key, parser.unique_field_name(xid.upper())],
+            [xyz_special_key, xid.upper()],
+            1,
+        )
+        score = self.subtest_similarity_score(
+            [fid, xid, xyz_special_key, parser.unique_field_name(fid), "a"],
+            [xyz_special_key, fid, "a"],
+            1,
+        )
+        score = self.subtest_similarity_score(
+            [fid, xid, xyz_special_key, parser.unique_field_name(fid), "a"],
+            [xyz_special_key, fid.upper(), "a"],
+            1 / 2,
+        )
 
     def test_complex(self):
-        feat_json = dict(properties=dict(a=1,b=2))
+        feat_json = dict(properties=dict(a=1, b=2))
         lst_fields = list()
         # prepare_fields
-        
+
+
 class TestUniqueFieldName(BaseTestAsync):
     def test_transform_unique_field_names(self):
         fid = parser.QGS_ID
@@ -145,19 +171,22 @@ class TestUniqueFieldName(BaseTestAsync):
         self.subtest_transform_unique_field_names("foobar")
         self.subtest_transform_unique_field_names("@ns:com:here:hello")
         self.subtest_transform_unique_field_names("foo.bar")
-        
+
     def subtest_transform_unique_field_names(self, orig_name):
         names = [orig_name]
-        names.extend([
-            "".join(s.upper() if i%k else s for i, s in enumerate(orig_name))
-            for k in [2,3,5]
-        ])
+        names.extend(
+            [
+                "".join(s.upper() if i % k else s for i, s in enumerate(orig_name))
+                for k in [2, 3, 5]
+            ]
+        )
         for name in names:
             with self.subTest(name=name):
                 field_name = parser.unique_field_name(name)
                 actual = parser.normal_field_name(field_name)
                 self._log_debug("{} -> {} -> {}".format(name, field_name, actual))
                 self.assertEqual(actual, name)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_layer_loader.py
+++ b/test/test_layer_loader.py
@@ -9,10 +9,16 @@
 ###############################################################################
 
 
-from qgis.testing import start_app, unittest 
-from test.utils import (BaseTestAsync, BaseTestWorkerAsync, 
-    add_test_fn_params, get_token_space, 
-    get_conn_info, AllErrorsDuringTest, slow_test)
+from qgis.testing import start_app, unittest
+from test.utils import (
+    BaseTestAsync,
+    BaseTestWorkerAsync,
+    add_test_fn_params,
+    get_token_space,
+    get_conn_info,
+    AllErrorsDuringTest,
+    slow_test,
+)
 from XYZHubConnector.xyz_qgis.network import NetManager
 from XYZHubConnector.xyz_qgis.loader import LoadLayerController, ManualInterrupt
 
@@ -24,18 +30,17 @@ network = NetManager(app)
 
 
 class TestLoader(BaseTestWorkerAsync):
-    """ test layer loader (chain of network, handler, parser, render, then repeat (after parser))
-    """
+    """test layer loader (chain of network, handler, parser, render, then repeat (after parser))"""
+
     def test_load_small_layer(self):
         self._test_load_small_layer(n_parallel=1)
+
     def _test_load_small_layer(self, n_parallel, **kw_start):
         conn_info = get_conn_info("water")
-        meta = dict(id="unittest",title="unittest",description="unittest")
+        meta = dict(id="unittest", title="unittest", description="unittest")
         feat_cnt = 527
         kw = dict(kw_start)
-        kw.update(dict(  
-            max_feat=600
-            ))
+        kw.update(dict(max_feat=600))
         self.subtest_load_layer(conn_info, meta, feat_cnt, n_parallel, **kw)
 
         # conn_info = get_conn_info("playground-pa")
@@ -43,77 +48,79 @@ class TestLoader(BaseTestWorkerAsync):
         # feat_cnt = 461
         # kw = dict(kw_start)
         # self.subtest_load_layer(conn_info, meta, feat_cnt, n_parallel,  **kw)
+
     def subtest_load_layer(self, conn_info, meta, feat_cnt, n_parallel, **kw_start):
         if feat_cnt is not None:
-            feat_cnt = min(feat_cnt, max(
-                kw_start.get("max_feat", feat_cnt), 
-                kw_start.get("limit", 30000)
-                ))
-        with self.subTest(conn_info=conn_info.get_xyz_space(), #meta=meta, 
-        feat_cnt=feat_cnt,n_parallel=n_parallel,**kw_start):
+            feat_cnt = min(
+                feat_cnt, max(kw_start.get("max_feat", feat_cnt), kw_start.get("limit", 30000))
+            )
+        with self.subTest(
+            conn_info=conn_info.get_xyz_space(),  # meta=meta,
+            feat_cnt=feat_cnt,
+            n_parallel=n_parallel,
+            **kw_start
+        ):
             loader = self._make_load_controller(n_parallel)
             layer = self._load_layer(loader, conn_info, meta, **kw_start)
             self._assert_layer(layer, feat_cnt)
             return layer
+
     def _load_layer(self, loader, conn_info, meta, **kw_start):
         loader.start(conn_info, meta, **kw_start)
         self._wait_async()
         return loader.layer
+
     def _assert_layer(self, layer, feat_cnt):
         feat_cnt_layer = layer.get_feat_cnt()
         self._log_debug("Feature count", feat_cnt_layer)
-        if feat_cnt is None: return
+        if feat_cnt is None:
+            return
         with self.subTest(actual_cnt=feat_cnt_layer):
             self.assertEqual(feat_cnt_layer, feat_cnt)
+
     def _make_load_controller(self, n_parallel):
         loader = LoadLayerController(network, n_parallel=n_parallel)
-        
+
         for f in loader.get_lst_fun():
             pass
             # self._log_debug("lst_fun", f)
             # f.signal.results.connect(self._log_debug)
             # f.signal.results.connect( self._add_output)
 
-        loader.signal.finished.connect( self._stop_async)
-        loader.signal.error.connect( self._handle_error)
-        loader.signal.error.connect( self._add_output)
+        loader.signal.finished.connect(self._stop_async)
+        loader.signal.error.connect(self._handle_error)
+        loader.signal.error.connect(self._add_output)
         return loader
-
 
     def _test_load_large_layer(self, n_parallel, **kw_start):
 
         conn_info_src = get_conn_info("here_world_carto")
-        meta = dict(id="unittest",title="unittest", description="uom_world_carto")
-        feat_cnt = 50573442 
+        meta = dict(id="unittest", title="unittest", description="uom_world_carto")
+        feat_cnt = 50573442
         kw = dict(kw_start)
-        kw.update(dict( 
-            max_feat=2000
-            ))
+        kw.update(dict(max_feat=2000))
         self.subtest_load_layer(conn_info_src, meta, feat_cnt, n_parallel, **kw)
 
         conn_info_src = get_conn_info("here_world_road")
-        meta = dict(id="unittest",title="unittest", description="uom_world_road")
+        meta = dict(id="unittest", title="unittest", description="uom_world_road")
         feat_cnt = None
         kw = dict(kw_start)
-        kw.update(dict(
-            max_feat=2000
-            ))
+        kw.update(dict(max_feat=2000))
         self.subtest_load_layer(conn_info_src, meta, feat_cnt, n_parallel, **kw)
 
         conn_info_src = get_conn_info("here_world_building")
-        meta = dict(id="unittest",title="unittest", description="uom_world_building")
+        meta = dict(id="unittest", title="unittest", description="uom_world_building")
         feat_cnt = None
         kw = dict(kw_start)
-        kw.update(dict( 
-            max_feat=2000
-            ))
+        kw.update(dict(max_feat=2000))
         self.subtest_load_layer(conn_info_src, meta, feat_cnt, n_parallel, **kw)
 
     def test_load_multi_start(self):
         pass
+
     def test_load_multi_start_async(self):
         pass
-        
+
     def setUp(self):
         QgsProject.instance().removeAllMapLayers()
         super().setUp()
@@ -122,10 +129,10 @@ class TestLoader(BaseTestWorkerAsync):
 class TestReLoader(TestLoader):
     def _load_layer(self, loader, conn_info, meta, **kw_start):
         lst_layer = list()
-        batch = 100 # kw_start.get("limit",30000)
+        batch = 100  # kw_start.get("limit",30000)
         for i in range(6):
             timer = QTimer()
-            timer.timeout.connect(lambda: self.check_loader(loader,batch))
+            timer.timeout.connect(lambda: self.check_loader(loader, batch))
             if not i:
                 loader.start(conn_info, meta, **kw_start)
             else:
@@ -140,40 +147,46 @@ class TestReLoader(TestLoader):
             finally:
                 timer.stop()
                 lst_layer.append(loader.layer)
-                
-            # with self.assertRaises(AllErrorsDuringTest, msg="stopping loader should emit error") as cm: 
+
+            # with self.assertRaises(AllErrorsDuringTest, msg="stopping loader should emit error") as cm:
             #     self._wait_async()
             # lst_err = cm.exception.args[0]
             # self.assertIsInstance(lst_err[0], ManualInterrupt)
-        
+
         return lst_layer
+
     def _assert_layer(self, lst_layer, feat_cnt):
-        batch = 100 # kw_start.get("limit",30000)
+        batch = 100  # kw_start.get("limit",30000)
         cnt = min(batch, feat_cnt)
         for i, layer in enumerate(lst_layer):
             with self.subTest(layer=i):
-                self.assertIs(layer,lst_layer[0])
+                self.assertIs(layer, lst_layer[0])
                 super()._assert_layer(layer, cnt)
-    
-    def check_loader(self,loader,feat_cnt):
-        if not hasattr(loader,"layer"):
+
+    def check_loader(self, loader, feat_cnt):
+        if not hasattr(loader, "layer"):
             return
         # self._log_debug("cnt",loader.get_feat_cnt())
         if loader.get_feat_cnt() >= feat_cnt:
-            self._log_debug("\n\n\n\nstop loop",loader.get_feat_cnt())
+            self._log_debug("\n\n\n\nstop loop", loader.get_feat_cnt())
 
             loader.stop_loop()
 
 
-for n_parallel in [1,2,4,8]:
-    add_test_fn_params(TestLoader,"_test_load_small_layer",n_parallel=n_parallel)
-    add_test_fn_params(TestLoader,"_test_load_large_layer",n_parallel=n_parallel)
-    for limit in [100,1000,100000]:
-        add_test_fn_params(TestLoader,"_test_load_small_layer",n_parallel=n_parallel, limit=limit)
-        add_test_fn_params(TestLoader,"_test_load_large_layer",n_parallel=n_parallel, limit=limit)
+for n_parallel in [1, 2, 4, 8]:
+    add_test_fn_params(TestLoader, "_test_load_small_layer", n_parallel=n_parallel)
+    add_test_fn_params(TestLoader, "_test_load_large_layer", n_parallel=n_parallel)
+    for limit in [100, 1000, 100000]:
+        add_test_fn_params(
+            TestLoader, "_test_load_small_layer", n_parallel=n_parallel, limit=limit
+        )
+        add_test_fn_params(
+            TestLoader, "_test_load_large_layer", n_parallel=n_parallel, limit=limit
+        )
 
-        add_test_fn_params(TestReLoader,"_test_load_small_layer",n_parallel=n_parallel, limit=limit)
-
+        add_test_fn_params(
+            TestReLoader, "_test_load_small_layer", n_parallel=n_parallel, limit=limit
+        )
 
 
 if __name__ == "__main__":
@@ -181,11 +194,9 @@ if __name__ == "__main__":
     tests = [
         # "TestReLoader.test_load_small_layer_n_parallel_1_limit_100",
         "TestReLoader.test_load_small_layer_n_parallel_2_limit_100",
-
         # "TestLoader.test_load_small_layer_n_parallel_2_limit_100",
         # "TestLoader.test_load_small_layer_n_parallel_2_limit_100000",
         # "TestLoader.test_load_large_layer_n_parallel_2_limit_1000",
-
         # "TestLoader.test_load_large_layer_n_parallel_2_limit_100",
         # "TestLoader.test_load_small_layer_n_parallel_4_limit_100000", # large limit: test retry
         # "TestLoader.test_load_small_layer_n_parallel_4_limit_100",
@@ -194,5 +205,4 @@ if __name__ == "__main__":
         # "TestLoader.test_load_small_layer_n_parallel_8",
     ]
     # unittest.main(defaultTest = tests, failfast=True) # will not run all subtest
-    unittest.main(defaultTest = tests)
-    
+    unittest.main(defaultTest=tests)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -99,7 +99,7 @@ class TestParser(BaseTestAsync):
             geom = json.loads(
                 ft.geometry().asJson()
             )  # limited to 13 or 14 precison (ogr.CreateGeometryFromJson)
-            self.assertEqual(geom["type"], geom_str)
+            self.assertEqual(geom and geom["type"], geom_str)
 
     def _assert_parsed_geom(self, obj_feat, feat, fields):
 
@@ -246,6 +246,11 @@ class TestParser(BaseTestAsync):
                 lst_fields = list(map_fields.values())[0]
                 for k in lst_k:
                     self.assertIn(k, lst_fields[0].names())
+
+                for k in lst_new_k:
+                    self.assertIn(k, [parser.normal_field_name(n) for n in lst_fields[0].names()])
+
+                return
 
                 # debug
                 debug_msg += format_long_args("\n", lst_fields[0].names())

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -11,9 +11,15 @@ import json
 import random
 import numpy as np
 
-from test.utils import (BaseTestAsync, TestFolder, format_long_args,
-                        len_of_struct, len_of_struct_sorted, flatten,
-                        format_map_fields)
+from test.utils import (
+    BaseTestAsync,
+    TestFolder,
+    format_long_args,
+    len_of_struct,
+    len_of_struct_sorted,
+    flatten,
+    format_map_fields,
+)
 
 from qgis.core import QgsFields, QgsVectorLayer
 from qgis.testing import unittest
@@ -23,22 +29,21 @@ from XYZHubConnector.xyz_qgis.layer import parser
 # import unittest
 # class TestParser(BaseTestAsync, unittest.TestCase):
 class TestParser(BaseTestAsync):
-    def __init__(self,*a,**kw):
-        super().__init__(*a,**kw)
-        self.similarity_threshold=80
-    ######## Parse xyz geojson -> QgsFeature 
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.similarity_threshold = 80
+
+    ######## Parse xyz geojson -> QgsFeature
     def test_parse_xyzjson(self):
         folder = "xyzjson-small"
-        fnames = [
-            "airport-xyz.geojson",
-            "water-xyz.geojson"
-            ]
+        fnames = ["airport-xyz.geojson", "water-xyz.geojson"]
         for fname in fnames:
-            self.subtest_parse_xyzjson(folder,fname)
-    def subtest_parse_xyzjson(self,folder,fname):
-        with self.subTest(folder=folder,fname=fname):
+            self.subtest_parse_xyzjson(folder, fname)
+
+    def subtest_parse_xyzjson(self, folder, fname):
+        with self.subTest(folder=folder, fname=fname):
             resource = TestFolder(folder)
-            
+
             txt = resource.load(fname)
             obj = json.loads(txt)
             obj_feat = obj["features"]
@@ -47,6 +52,7 @@ class TestParser(BaseTestAsync):
 
             self._assert_parsed_fields(obj_feat, feat, fields)
             self._assert_parsed_geom(obj_feat, feat, fields)
+
     def _assert_parsed_fields_unorder(self, obj_feat, feat, fields):
         # self._log_debug(fields.names())
         # self._log_debug("debug id, json vs. QgsFeature")
@@ -54,9 +60,8 @@ class TestParser(BaseTestAsync):
         # self._log_debug([ft.attribute(parser.QGS_XYZ_ID) for ft in feat])
 
         names = fields.names()
-        self.assertTrue(parser.QGS_XYZ_ID in names, 
-            "%s %s" % (len(names), names))
-        self.assertEqual( len(obj_feat), len(feat))
+        self.assertTrue(parser.QGS_XYZ_ID in names, "%s %s" % (len(names), names))
+        self.assertEqual(len(obj_feat), len(feat))
 
     def _assert_parsed_fields(self, obj_feat, feat, fields):
         self._assert_parsed_fields_unorder(obj_feat, feat, fields)
@@ -66,34 +71,43 @@ class TestParser(BaseTestAsync):
                 "{sep}{0}{sep}{1}"
                 "{sep}fields-props {2}"
                 "{sep}props-fields {3}"
-                "{sep}json {4}"
-                .format(*tuple(map(
-                    lambda x: "%s %s" % (len(x), x), [
-                    obj_props, 
-                    fields.names(),
-                    set(fields.names()).difference(obj_props),
-                    set(obj_props).difference(fields.names())
-                    ])),
+                "{sep}json {4}".format(
+                    *tuple(
+                        map(
+                            lambda x: "%s %s" % (len(x), x),
+                            [
+                                obj_props,
+                                fields.names(),
+                                set(fields.names()).difference(obj_props),
+                                set(obj_props).difference(fields.names()),
+                            ],
+                        )
+                    ),
                     format_long_args(json.dumps(obj)),
-                    sep="\n>> ")
+                    sep="\n>> "
                 )
-            
+            )
+
         for o in obj_feat:
             obj_props = list(o["properties"].keys())
-            self.assertLessEqual( len(obj_props), fields.size(), msg_fields(o))
-            self.assertTrue( set(obj_props) < set(fields.names()), msg_fields(o))
+            self.assertLessEqual(len(obj_props), fields.size(), msg_fields(o))
+            self.assertTrue(set(obj_props) < set(fields.names()), msg_fields(o))
             # self.assertEqual( obj_props, fields.names(), msg_fields(o)) # strict assert
-            
+
     def _assert_parsed_geom_unorder(self, obj_feat, feat, fields, geom_str):
         for ft in feat:
-            geom = json.loads(ft.geometry().asJson()) # limited to 13 or 14 precison (ogr.CreateGeometryFromJson)
+            geom = json.loads(
+                ft.geometry().asJson()
+            )  # limited to 13 or 14 precison (ogr.CreateGeometryFromJson)
             self.assertEqual(geom["type"], geom_str)
 
     def _assert_parsed_geom(self, obj_feat, feat, fields):
 
         # both crs is WGS84
         for o, ft in zip(obj_feat, feat):
-            geom = json.loads(ft.geometry().asJson()) # limited to 13 or 14 precison (ogr.CreateGeometryFromJson)
+            geom = json.loads(
+                ft.geometry().asJson()
+            )  # limited to 13 or 14 precison (ogr.CreateGeometryFromJson)
             obj_geom = o["geometry"]
 
             self.assertEqual(geom["type"], obj_geom["type"])
@@ -110,21 +124,22 @@ class TestParser(BaseTestAsync):
             # obj_geom["coordinates"] = [float("%.13f"%c) for c in coords]
             # self.assertDictEqual(geom, obj_geom) # precision
             # for c1, c2 in zip(geom["coordinates"], obj_geom["coordinates"]):
-                # self.assertAlmostEqual(c1, c2, places=13)
-            
+            # self.assertAlmostEqual(c1, c2, places=13)
+
             c1 = np.array(obj_geom["coordinates"])
             c2 = np.array(geom["coordinates"])
             if c1.shape != c2.shape:
                 self._log_debug(
                     "\nWARNING: Geometry has mismatch shape",
-                    c1.shape, c2.shape,
-                    "\nOriginal geom has problem. Testing parsed geom..")
-                self.assertEqual(c2.shape[-1], 2, 
-                    "parsed geom has wrong shape of coord")
+                    c1.shape,
+                    c2.shape,
+                    "\nOriginal geom has problem. Testing parsed geom..",
+                )
+                self.assertEqual(c2.shape[-1], 2, "parsed geom has wrong shape of coord")
                 continue
             else:
-                self.assertLess( np.max(np.abs(c1 - c2)), 1e-13,
-                    "parsed geometry error > 1e-13")
+                self.assertLess(np.max(np.abs(c1 - c2)), 1e-13, "parsed geometry error > 1e-13")
+
     # @unittest.skip("large")
     def test_parse_xyzjson_large(self):
         folder = "xyzjson-large"
@@ -133,8 +148,8 @@ class TestParser(BaseTestAsync):
             "cmcs-osm-dev-building-xyz-30000.geojson",
         ]
         for fname in fnames:
-            self.subtest_parse_xyzjson(folder,fname)
-    
+            self.subtest_parse_xyzjson(folder, fname)
+
     ######## Parse xyz geojson -> struct of geom: [fields], [[QgsFeature]]
     def test_parse_xyzjson_map(self):
         folder = "xyzjson-small"
@@ -142,13 +157,14 @@ class TestParser(BaseTestAsync):
             "mixed-xyz.geojson",
         ]
         for fname in fnames:
-            self.subtest_parse_xyzjson_map(folder,fname)
-        
+            self.subtest_parse_xyzjson_map(folder, fname)
+
         mix_fnames = [
             "airport-xyz.geojson",
             "water-xyz.geojson",
         ]
-        self.subtest_parse_xyzjson_mix(folder,mix_fnames)
+        self.subtest_parse_xyzjson_mix(folder, mix_fnames)
+
     def test_parse_xyzjson_map_similarity_0(self):
         s = self.similarity_threshold
         self.similarity_threshold = 0
@@ -157,17 +173,17 @@ class TestParser(BaseTestAsync):
             fnames = [
                 "mixed-xyz.geojson",
             ]
-            
+
             for fname in fnames:
-                with self.subTest(folder=folder,fname=fname,
-                similarity_threshold=self.similarity_threshold):
-                    map_fields = self._parse_xyzjson_map_simple(folder,fname)
+                with self.subTest(
+                    folder=folder, fname=fname, similarity_threshold=self.similarity_threshold
+                ):
+                    map_fields = self._parse_xyzjson_map_simple(folder, fname)
                     self._assert_map_fields_similarity_0(map_fields)
 
         finally:
             self.similarity_threshold = s
 
-    
     def test_parse_xyzjson_map_dupe_case(self):
         folder = "xyzjson-small"
         fnames = [
@@ -175,30 +191,32 @@ class TestParser(BaseTestAsync):
             "water-xyz.geojson",
         ]
         for fname in fnames:
-            self.subtest_parse_xyzjson_map_dupe_case(folder,fname)
-    
-    def _parse_xyzjson_map_simple(self,folder,fname):
+            self.subtest_parse_xyzjson_map_dupe_case(folder, fname)
+
+    def _parse_xyzjson_map_simple(self, folder, fname):
         resource = TestFolder(folder)
         txt = resource.load(fname)
         obj = json.loads(txt)
         return self.subtest_parse_xyzjson_map_chunk(obj)
 
-
-    def subtest_parse_xyzjson_map_dupe_case(self,folder,fname):
-        with self.subTest(folder=folder,fname=fname):
+    def subtest_parse_xyzjson_map_dupe_case(self, folder, fname):
+        with self.subTest(folder=folder, fname=fname):
             import random
-            mix_case = lambda txt, idx: "".join([
-                (s.lower() if s.isupper() else s.upper()) 
-                if i == idx else s
-                for i, s in enumerate(txt)])
+
+            mix_case = lambda txt, idx: "".join(
+                [
+                    (s.lower() if s.isupper() else s.upper()) if i == idx else s
+                    for i, s in enumerate(txt)
+                ]
+            )
             new_feat = lambda ft, props: dict(ft, properties=dict(props))
             n_new_ft = 2
-            with self.subTest(folder=folder,fname=fname):
+            with self.subTest(folder=folder, fname=fname):
                 resource = TestFolder(folder)
                 txt = resource.load(fname)
                 obj = json.loads(txt)
                 features = obj["features"]
-                features[0]["properties"].update(fid=1) # test fid
+                features[0]["properties"].update(fid=1)  # test fid
                 lst_k = list()
                 lst_new_k = list()
                 props_ = dict(obj["features"][0]["properties"])
@@ -211,18 +229,20 @@ class TestParser(BaseTestAsync):
                         props = dict(ft["properties"])
                         new_k = k
                         while new_k == k:
-                            idx = random.randint(0,len(k)-1)
-                            if k == "fid": idx = i
+                            idx = random.randint(0, len(k) - 1)
+                            if k == "fid":
+                                idx = i
                             new_k = mix_case(k, idx)
-                        if new_k not in lst_new_k: lst_new_k.append(new_k)
+                        if new_k not in lst_new_k:
+                            lst_new_k.append(new_k)
                         debug_msg += format_long_args("\n", "mix_case", k, new_k, props[k], idx)
                         props[new_k] = props.pop(k) or ""
                         new_ft = new_feat(ft, props)
                         features.append(new_ft)
-                map_fields = self.subtest_parse_xyzjson_map_chunk(obj,chunk_size=1)
+                map_fields = self.subtest_parse_xyzjson_map_chunk(obj, chunk_size=1)
 
                 # assert that parser handle dupe of case insensitive prop name, e.g. name vs Name
-                self.assertEqual(len(map_fields),1, "not single geom")
+                self.assertEqual(len(map_fields), 1, "not single geom")
                 lst_fields = list(map_fields.values())[0]
                 for k in lst_k:
                     self.assertIn(k, lst_fields[0].names())
@@ -231,37 +251,39 @@ class TestParser(BaseTestAsync):
                 debug_msg += format_long_args("\n", lst_fields[0].names())
                 for k, fields in zip(lst_new_k, lst_fields[1:]):
                     if k.lower() in {parser.QGS_ID, parser.QGS_XYZ_ID}:
-                        k = "{}_{}".format(k, 
-                        "".join(str(i) for i, s in enumerate(k) if s.isupper()))
+                        k = "{}_{}".format(
+                            k, "".join(str(i) for i, s in enumerate(k) if s.isupper())
+                        )
                     debug_msg += format_long_args("\n", k in fields.names(), k, fields.names())
 
                 # self.assertEqual(len(lst_fields), len(lst_new_k) + 1)
                 for k, fields in zip(lst_new_k, lst_fields[1:]):
                     if k.lower() in {parser.QGS_ID, parser.QGS_XYZ_ID}:
-                        k = "{}_{}".format(k, 
-                        "".join(str(i) for i, s in enumerate(k) if s.isupper()))
-                    self.assertIn(k, fields.names(), 
-                    "len lst_fields vs. len keys: %s != %s" %
-                    (len(lst_fields), len(lst_new_k) + 1) +
-                    debug_msg
+                        k = "{}_{}".format(
+                            k, "".join(str(i) for i, s in enumerate(k) if s.isupper())
+                        )
+                    self.assertIn(
+                        k,
+                        fields.names(),
+                        "len lst_fields vs. len keys: %s != %s"
+                        % (len(lst_fields), len(lst_new_k) + 1)
+                        + debug_msg,
                     )
 
-    def subtest_parse_xyzjson_map(self,folder,fname):
-        with self.subTest(folder=folder,fname=fname):
+    def subtest_parse_xyzjson_map(self, folder, fname):
+        with self.subTest(folder=folder, fname=fname):
             resource = TestFolder(folder)
             txt = resource.load(fname)
             obj = json.loads(txt)
             self.subtest_parse_xyzjson_map_shuffle(obj)
             self.subtest_parse_xyzjson_map_multi_chunk(obj)
-            
-    def subtest_parse_xyzjson_mix(self,folder,fnames):
-        if len(fnames) < 2: return
-        with self.subTest(folder=folder, fname="mix:"+",".join(fnames)):
+
+    def subtest_parse_xyzjson_mix(self, folder, fnames):
+        if len(fnames) < 2:
+            return
+        with self.subTest(folder=folder, fname="mix:" + ",".join(fnames)):
             resource = TestFolder(folder)
-            lst_obj = [
-                json.loads(resource.load(fname))
-                for fname in fnames
-            ]
+            lst_obj = [json.loads(resource.load(fname)) for fname in fnames]
             obj = lst_obj[0]
             for o in lst_obj[1:]:
                 obj["features"].extend(o["features"])
@@ -272,21 +294,21 @@ class TestParser(BaseTestAsync):
 
     def subtest_parse_xyzjson_map_multi_chunk(self, obj, lst_chunk_size=None):
         if not lst_chunk_size:
-            p10 = 1+len(str(len(obj["features"])))
-            lst_chunk_size = [10**i for i in range(p10)]
+            p10 = 1 + len(str(len(obj["features"])))
+            lst_chunk_size = [10 ** i for i in range(p10)]
         with self.subTest(lst_chunk_size=lst_chunk_size):
             ref_map_feat, ref_map_fields = self.do_test_parse_xyzjson_map(obj)
             lst_map_fields = list()
             for chunk_size in lst_chunk_size:
                 map_fields = self.subtest_parse_xyzjson_map_chunk(obj, chunk_size)
-                if map_fields is None: continue
+                if map_fields is None:
+                    continue
                 lst_map_fields.append(map_fields)
-                
+
             for map_fields, chunk_size in zip(lst_map_fields, lst_chunk_size):
                 with self.subTest(chunk_size=chunk_size):
-                    self._assert_len_map_fields(
-                        map_fields, ref_map_fields)
-    
+                    self._assert_len_map_fields(map_fields, ref_map_fields)
+
     def subtest_parse_xyzjson_map_shuffle(self, obj, n_shuffle=5, chunk_size=10):
         with self.subTest(n_shuffle=n_shuffle):
             o = dict(obj)
@@ -296,15 +318,15 @@ class TestParser(BaseTestAsync):
             for i in range(n_shuffle):
                 random.shuffle(o["features"])
                 map_fields = self.subtest_parse_xyzjson_map_chunk(o, chunk_size)
-                if map_fields is None: continue
+                if map_fields is None:
+                    continue
                 lst_map_fields.append(map_fields)
-                
+
                 # self._log_debug("parsed fields shuffle", len_of_struct(map_fields))
 
             for i, map_fields in enumerate(lst_map_fields):
                 with self.subTest(shuffle=i):
-                    self._assert_len_map_fields(
-                        map_fields, ref_map_fields)
+                    self._assert_len_map_fields(map_fields, ref_map_fields)
 
     def subtest_parse_xyzjson_map_chunk(self, obj, chunk_size=100):
         similarity_threshold = self.similarity_threshold
@@ -313,8 +335,8 @@ class TestParser(BaseTestAsync):
             obj_feat = obj["features"]
             lst_map_feat = list()
             map_fields = dict()
-            for i0 in range(0,len(obj_feat), chunk_size):
-                chunk = obj_feat[i0:i0+chunk_size]
+            for i0 in range(0, len(obj_feat), chunk_size):
+                chunk = obj_feat[i0 : i0 + chunk_size]
                 o["features"] = chunk
                 map_feat, _ = parser.xyz_json_to_feature_map(o, map_fields, similarity_threshold)
                 self._assert_parsed_map(chunk, map_feat, map_fields)
@@ -327,13 +349,15 @@ class TestParser(BaseTestAsync):
             lst_feat = flatten([x.values() for x in lst_map_feat])
             self.assertEqual(len(lst_feat), len(obj["features"]))
             return map_fields
-    
+
     def do_test_parse_xyzjson_map(self, obj, similarity_threshold=None):
         obj_feat = obj["features"]
         # map_fields=dict()
-        if similarity_threshold is None: 
+        if similarity_threshold is None:
             similarity_threshold = self.similarity_threshold
-        map_feat, map_fields = parser.xyz_json_to_feature_map(obj, similarity_threshold=similarity_threshold)
+        map_feat, map_fields = parser.xyz_json_to_feature_map(
+            obj, similarity_threshold=similarity_threshold
+        )
 
         self._log_debug("len feat", len(obj_feat))
         self._log_debug("parsed feat", len_of_struct(map_feat))
@@ -345,44 +369,53 @@ class TestParser(BaseTestAsync):
     def _assert_len_map_fields(self, map_fields, ref, strict=False):
         len_ = len_of_struct if strict else len_of_struct_sorted
         self.assertEqual(
-            len_(map_fields), len_(ref), "\n".join([
-                "map_fields, ref_map_fields",
-                format_map_fields(map_fields),
-                format_map_fields(ref),
-                ])
-            )
-        
+            len_(map_fields),
+            len_(ref),
+            "\n".join(
+                [
+                    "map_fields, ref_map_fields",
+                    format_map_fields(map_fields),
+                    format_map_fields(ref),
+                ]
+            ),
+        )
+
     def _assert_parsed_map(self, obj_feat, map_feat, map_fields):
         self._assert_len_map_feat_fields(map_feat, map_fields)
-        self.assertEqual(len(obj_feat), 
-            sum(len(lst) 
-            for lst_lst in map_feat.values() 
-            for lst in lst_lst),
-            "total len of parsed feat incorrect")
+        self.assertEqual(
+            len(obj_feat),
+            sum(len(lst) for lst_lst in map_feat.values() for lst in lst_lst),
+            "total len of parsed feat incorrect",
+        )
 
         # NOTE: obj_feat order does not corresponds to that of map_feat
         # -> use unorder assert
         for geom_str in map_feat:
             for feat, fields in zip(map_feat[geom_str], map_fields[geom_str]):
-                o = obj_feat[:len(feat)]
+                o = obj_feat[: len(feat)]
                 self._assert_parsed_fields_unorder(o, feat, fields)
                 self._assert_parsed_geom_unorder(o, feat, fields, geom_str)
-                obj_feat = obj_feat[len(feat):]
+                obj_feat = obj_feat[len(feat) :]
 
     def _assert_len_map_feat_fields(self, map_feat, map_fields):
         self.assertEqual(map_feat.keys(), map_fields.keys())
         for geom_str in map_feat:
-            self.assertEqual(len(map_feat[geom_str]), len(map_fields[geom_str]),
-            "len mismatch: map_feat, map_fields" +
-            "\n %s \n %s" % (len_of_struct(map_feat), len_of_struct(map_fields))
+            self.assertEqual(
+                len(map_feat[geom_str]),
+                len(map_fields[geom_str]),
+                "len mismatch: map_feat, map_fields"
+                + "\n %s \n %s" % (len_of_struct(map_feat), len_of_struct(map_fields)),
             )
-    
+
     def _assert_map_fields_similarity_0(self, map_fields):
-        fields_cnt = {k:len(lst_fields) for k, lst_fields in map_fields.items()}
-        ref = {k:1 for k in map_fields}
-        self.assertEqual(fields_cnt, ref, 
-        "given similarity_threshold=0, " + 
-        "map_fields should have exact 1 layer/fields per geom")
+        fields_cnt = {k: len(lst_fields) for k, lst_fields in map_fields.items()}
+        ref = {k: 1 for k in map_fields}
+        self.assertEqual(
+            fields_cnt,
+            ref,
+            "given similarity_threshold=0, "
+            + "map_fields should have exact 1 layer/fields per geom",
+        )
 
     def test_parse_xyzjson_map_large(self):
         folder = "xyzjson-large"
@@ -391,33 +424,36 @@ class TestParser(BaseTestAsync):
             "cmcs-osm-dev-road-xyz.geojson",
         ]
         for fname in fnames:
-            self.subtest_parse_xyzjson_map(folder,fname)
+            self.subtest_parse_xyzjson_map(folder, fname)
 
-    ######## Parse QgsFeature -> json 
+    ######## Parse QgsFeature -> json
     def test_parse_qgsfeature(self):
-        self.subtest_parse_qgsfeature("geojson-small","airport-qgis.geojson") # no xyz_id
+        self.subtest_parse_qgsfeature("geojson-small", "airport-qgis.geojson")  # no xyz_id
 
-    def subtest_parse_qgsfeature(self,folder,fname):
+    def subtest_parse_qgsfeature(self, folder, fname):
         # qgs layer load geojson -> qgs feature
         # parse feature to xyz geojson
         # compare geojson and xyzgeojson
-        with self.subTest(folder=folder,fname=fname):
-        
-            resource = TestFolder(folder) 
+        with self.subTest(folder=folder, fname=fname):
+
+            resource = TestFolder(folder)
             path = resource.fullpath(fname)
             txt = resource.load(fname)
             obj = json.loads(txt)
 
             vlayer = QgsVectorLayer(path, "test", "ogr")
-            feat = parser.feature_to_xyz_json(list(vlayer.getFeatures()),is_new=True) # remove QGS_XYZ_ID if exist
+            feat = parser.feature_to_xyz_json(
+                list(vlayer.getFeatures()), is_new=True
+            )  # remove QGS_XYZ_ID if exist
             self._log_debug(feat)
 
-            self.assertListEqual(obj["features"],feat)
-            self.assertEqual(len(obj["features"]),len(feat))
+            self.assertListEqual(obj["features"], feat)
+            self.assertEqual(len(obj["features"]), len(feat))
 
     def test_parse_qgsfeature_large(self):
         pass
-        
+
+
 if __name__ == "__main__":
     # unittest.main()
 
@@ -428,7 +464,6 @@ if __name__ == "__main__":
         # "TestParser.test_parse_xyzjson_map_dupe_case",
         # "TestParser.test_parse_xyzjson_large",
         # "TestParser.test_parse_xyzjson_map_large",
-        
     ]
     # unittest.main(defaultTest = tests, failfast=True) # will not run all subtest
-    unittest.main(defaultTest = tests)
+    unittest.main(defaultTest=tests)

--- a/test/test_render_layer.py
+++ b/test/test_render_layer.py
@@ -12,9 +12,15 @@ import random
 import numpy as np
 import pprint
 
-from test.utils import (BaseTestAsync, TestFolder, format_long_args,
-                        len_of_struct, len_of_struct_sorted, flatten,
-                        format_map_fields)
+from test.utils import (
+    BaseTestAsync,
+    TestFolder,
+    format_long_args,
+    len_of_struct,
+    len_of_struct_sorted,
+    flatten,
+    format_map_fields,
+)
 from test import test_parser
 from qgis.testing import unittest
 from qgis.core import QgsWkbTypes, QgsProject
@@ -25,26 +31,28 @@ from XYZHubConnector.xyz_qgis.layer import XYZLayer, parser, render
 # class TestParser(BaseTestAsync, unittest.TestCase):
 class TestRenderLayer(BaseTestAsync):
     _assert_len_map_fields = test_parser.TestParser._assert_len_map_fields
-    def __init__(self,*a,**kw):
-        super().__init__(*a,**kw)
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
         test_parser.TestParser._id = lambda x: self._id()
+
     def test_render_mixed_json_to_layer_chunk(self):
-        folder="xyzjson-small"
-        fnames=[
+        folder = "xyzjson-small"
+        fnames = [
             "mixed-xyz.geojson",
         ]
         for fname in fnames:
             self.subtest_render_mixed_json_to_layer(folder, fname)
 
-    def subtest_render_mixed_json_to_layer(self,folder,fname):
-        with self.subTest(folder=folder,fname=fname):
+    def subtest_render_mixed_json_to_layer(self, folder, fname):
+        with self.subTest(folder=folder, fname=fname):
             resource = TestFolder(folder)
             txt = resource.load(fname)
             obj = json.loads(txt)
             ref_map_feat, ref_map_fields = self._test_render_mixed_json_to_layer(obj)
-            
+
             ref = dict()
-            ref_len_fields = {'MultiPoint': [6, 18], 'MultiPolygon': [27]}
+            ref_len_fields = {"MultiPoint": [6, 18], "MultiPolygon": [27]}
             ref["len_fields"] = ref_len_fields
             with self.subTest():
                 self._assert_len_fields(ref_map_fields, ref_len_fields)
@@ -58,19 +66,20 @@ class TestRenderLayer(BaseTestAsync):
 
     def subtest_render_mixed_json_to_layer_multi_chunk(self, obj, ref, lst_chunk_size=None):
         if not lst_chunk_size:
-            p10 = 1+len(str(len(obj["features"])))
-            lst_chunk_size = [10**i for i in range(p10)]
+            p10 = 1 + len(str(len(obj["features"])))
+            lst_chunk_size = [10 ** i for i in range(p10)]
         with self.subTest(lst_chunk_size=lst_chunk_size):
             lst_map_fields = list()
             for chunk_size in lst_chunk_size:
                 map_fields = self.subtest_render_mixed_json_to_layer_chunk(obj, chunk_size)
-                if map_fields is None: continue
+                if map_fields is None:
+                    continue
                 lst_map_fields.append(map_fields)
 
             for map_fields, chunk_size in zip(lst_map_fields, lst_chunk_size):
                 with self.subTest(chunk_size=chunk_size):
-                    self._assert_len_ref_fields(
-                        map_fields, ref)
+                    self._assert_len_ref_fields(map_fields, ref)
+
     def subtest_render_mixed_json_to_layer_shuffle(self, obj, ref, n_shuffle=5, chunk_size=10):
         with self.subTest(n_shuffle=n_shuffle):
             o = dict(obj)
@@ -79,19 +88,23 @@ class TestRenderLayer(BaseTestAsync):
             for i in range(n_shuffle):
                 random.shuffle(o["features"])
                 map_fields = self.subtest_render_mixed_json_to_layer_chunk(o, chunk_size)
-                if map_fields is None: continue
+                if map_fields is None:
+                    continue
                 lst_map_fields.append(map_fields)
-                
+
             for i, map_fields in enumerate(lst_map_fields):
                 with self.subTest(shuffle=i):
-                    self._assert_len_ref_fields(
-                        map_fields, ref)
-    def subtest_render_mixed_json_to_layer_empty_chunk(self, obj, ref, chunk_size=10,empty_chunk=10):
+                    self._assert_len_ref_fields(map_fields, ref)
+
+    def subtest_render_mixed_json_to_layer_empty_chunk(
+        self, obj, ref, chunk_size=10, empty_chunk=10
+    ):
         with self.subTest(empty_chunk=empty_chunk):
-            map_fields = self.subtest_render_mixed_json_to_layer_chunk(obj, chunk_size, empty_chunk=empty_chunk)
+            map_fields = self.subtest_render_mixed_json_to_layer_chunk(
+                obj, chunk_size, empty_chunk=empty_chunk
+            )
             self.assertIsNotNone(map_fields)
-            self._assert_len_ref_fields(
-                map_fields, ref)
+            self._assert_len_ref_fields(map_fields, ref)
 
     def subtest_render_mixed_json_to_layer_chunk(self, obj, chunk_size=100, empty_chunk=None):
         with self.subTest(chunk_size=chunk_size):
@@ -100,10 +113,11 @@ class TestRenderLayer(BaseTestAsync):
             obj_feat = obj["features"]
             lst_map_feat = list()
             map_fields = dict()
-            lst_chunk: list = [obj_feat[i0:i0+chunk_size]
-            for i0 in range(0,len(obj_feat), chunk_size)]
+            lst_chunk: list = [
+                obj_feat[i0 : i0 + chunk_size] for i0 in range(0, len(obj_feat), chunk_size)
+            ]
             if empty_chunk:
-                step = max(2,len(lst_chunk)//empty_chunk)
+                step = max(2, len(lst_chunk) // empty_chunk)
                 for i in reversed(range(0, len(lst_chunk), step)):
                     lst_chunk.insert(i, list())
             for chunk in lst_chunk:
@@ -124,14 +138,16 @@ class TestRenderLayer(BaseTestAsync):
 
             self.remove_layer(layer)
             return map_fields
-            
+
     def _assert_rendered_fields(self, vlayer, fields):
         name_vlayer_fields = vlayer.fields().names()
         name_fields = fields.names()
 
-        self.assertEqual(name_vlayer_fields, name_fields, 
-            "layer fields and parsed fields mismatch. len: %s and %s" %
-            (len(name_vlayer_fields), len(name_fields))
+        self.assertEqual(
+            name_vlayer_fields,
+            name_fields,
+            "layer fields and parsed fields mismatch. len: %s and %s"
+            % (len(name_vlayer_fields), len(name_fields)),
         )
 
     def _test_render_mixed_json_to_layer(self, obj):
@@ -141,15 +157,15 @@ class TestRenderLayer(BaseTestAsync):
         self._render_layer(layer, map_feat, map_fields)
         self.assert_layer(layer, obj, map_fields)
         return map_feat, map_fields
-        
+
     def _render_layer(self, layer, map_feat, map_fields):
         for geom_str in map_feat:
-            for idx,(feat, fields) in enumerate(zip(
-                map_feat[geom_str], map_fields[geom_str])):
+            for idx, (feat, fields) in enumerate(zip(map_feat[geom_str], map_fields[geom_str])):
                 vlayer = (
-                    layer.get_layer(geom_str, idx) 
+                    layer.get_layer(geom_str, idx)
                     if layer.has_layer(geom_str, idx)
-                    else layer.add_ext_layer(geom_str, idx))
+                    else layer.add_ext_layer(geom_str, idx)
+                )
                 ok, out_feat = render.add_feature_render(vlayer, feat, fields)
                 if not ok:
                     self._log_debug(ok, len(feat), len(out_feat), vlayer.id())
@@ -167,23 +183,27 @@ class TestRenderLayer(BaseTestAsync):
     def _assert_len_fields(self, map_fields, ref, strict=False):
         len_ = len_of_struct if strict else len_of_struct_sorted
         self.assertEqual(
-            len_(map_fields), ref, "\n".join([
-                "len of map_fields is not correct (vs. ref). "+
-                "Please revised parser, similarity threshold.",
-                format_map_fields(map_fields),
-                ])
-            )
+            len_(map_fields),
+            ref,
+            "\n".join(
+                [
+                    "len of map_fields is not correct (vs. ref). "
+                    + "Please revised parser, similarity threshold.",
+                    format_map_fields(map_fields),
+                ]
+            ),
+        )
+
     def assert_layer(self, layer, obj, map_fields):
         lst_vlayer = list(layer.iter_layer())
         map_vlayer = layer.map_vlayer
 
-        len_fields = len_of_struct(map_fields) # field cnt
-        len_vlayer = len_of_struct(map_vlayer) # feat cnt
+        len_fields = len_of_struct(map_fields)  # field cnt
+        len_vlayer = len_of_struct(map_vlayer)  # feat cnt
         len_vlayer_fields = dict(
-            (geom_str, [len(x.fields()) for x in lst])
-            for geom_str, lst in map_vlayer.items()
-            )
-        
+            (geom_str, [len(x.fields()) for x in lst]) for geom_str, lst in map_vlayer.items()
+        )
+
         # self._log_debug("feat layer", len_vlayer)
         # self._log_debug("fields layer", len_vlayer_fields)
 
@@ -192,38 +212,39 @@ class TestRenderLayer(BaseTestAsync):
         cnt = layer.get_feat_cnt()
         self.assertEqual(cnt, len(obj["features"]), len_vlayer)
 
-        
         name_vlayer_fields = dict(
-            (geom_str,
-            [x.fields().names() for x in lst])
-            for geom_str, lst in map_vlayer.items()
-            )
+            (geom_str, [x.fields().names() for x in lst]) for geom_str, lst in map_vlayer.items()
+        )
 
         name_map_fields = dict(
-            (geom_str,
-            [x.names() for x in lst])
-            for geom_str, lst in map_fields.items()
-            )
-        self.assertEqual(len_vlayer_fields, len_fields, "\n".join([
-            "layer fields and map_fields mismatch",
-            pprint.pformat(name_vlayer_fields, compact=True),
-            pprint.pformat(name_map_fields, compact=True)
-            ])
+            (geom_str, [x.names() for x in lst]) for geom_str, lst in map_fields.items()
+        )
+        self.assertEqual(
+            len_vlayer_fields,
+            len_fields,
+            "\n".join(
+                [
+                    "layer fields and map_fields mismatch",
+                    pprint.pformat(name_vlayer_fields, compact=True),
+                    pprint.pformat(name_map_fields, compact=True),
+                ]
+            ),
         )
         self.assertEqual(name_vlayer_fields, name_map_fields)
-                    
+
         # lst_feat = list(vlayer.getFeatures())
         # self._log_debug(lst_feat)
-    def remove_layer(self,layer:XYZLayer):
+
+    def remove_layer(self, layer: XYZLayer):
         for vlayer in layer.iter_layer():
             QgsProject.instance().removeMapLayer(vlayer)
+
     def new_layer(self):
         conn_info = dict(tags=["tags"])
         meta = dict(title="title", id="id")
         layer = XYZLayer(conn_info, meta)
         return layer
-    
+
 
 if __name__ == "__main__":
     unittest.main()
-    

--- a/test/test_render_layer.py
+++ b/test/test_render_layer.py
@@ -26,6 +26,7 @@ from qgis.testing import unittest
 from qgis.core import QgsWkbTypes, QgsProject
 
 from XYZHubConnector.xyz_qgis.layer import XYZLayer, parser, render
+from XYZHubConnector.xyz_qgis.models import SpaceConnectionInfo
 
 # import unittest
 # class TestParser(BaseTestAsync, unittest.TestCase):
@@ -52,7 +53,7 @@ class TestRenderLayer(BaseTestAsync):
             ref_map_feat, ref_map_fields = self._test_render_mixed_json_to_layer(obj)
 
             ref = dict()
-            ref_len_fields = {"MultiPoint": [6, 18], "MultiPolygon": [27]}
+            ref_len_fields = {"MultiPoint": [3, 6, 18], "MultiPolygon": [27], None: [4]}
             ref["len_fields"] = ref_len_fields
             with self.subTest():
                 self._assert_len_fields(ref_map_fields, ref_len_fields)
@@ -136,7 +137,7 @@ class TestRenderLayer(BaseTestAsync):
 
             self.assert_layer(layer, obj, map_fields)
 
-            self.remove_layer(layer)
+            # self.remove_layer(layer) # skip if deleted layer clear map_fields
             return map_fields
 
     def _assert_rendered_fields(self, vlayer, fields):
@@ -240,7 +241,7 @@ class TestRenderLayer(BaseTestAsync):
             QgsProject.instance().removeMapLayer(vlayer)
 
     def new_layer(self):
-        conn_info = dict(tags=["tags"])
+        conn_info = SpaceConnectionInfo.from_dict(dict(tags=["tags"]))
         meta = dict(title="title", id="id")
         layer = XYZLayer(conn_info, meta)
         return layer

--- a/test/test_tile_loader.py
+++ b/test/test_tile_loader.py
@@ -9,10 +9,15 @@
 ###############################################################################
 
 
-from qgis.testing import start_app, unittest 
-from test.utils import (BaseTestAsync, BaseTestWorkerAsync, 
-    add_test_fn_params, get_token_space, 
-    get_conn_info, AllErrorsDuringTest)
+from qgis.testing import start_app, unittest
+from test.utils import (
+    BaseTestAsync,
+    BaseTestWorkerAsync,
+    add_test_fn_params,
+    get_token_space,
+    get_conn_info,
+    AllErrorsDuringTest,
+)
 from test.test_layer_loader import TestReLoader, TestLoader
 from XYZHubConnector.xyz_qgis.network import NetManager
 from XYZHubConnector.xyz_qgis.loader import TileLayerLoader, EmptyXYZSpaceError
@@ -27,9 +32,10 @@ network = NetManager(app)
 
 class TestTileLoader(TestLoader):
     flag_canvas = False
+
     def _test_load_small_layer(self, n_parallel, **kw_start):
         conn_info = get_conn_info("water")
-        meta = dict(id="unittest",title="unittest",description="unittest")
+        meta = dict(id="unittest", title="unittest", description="unittest")
         feat_cnt = 527
         kw = dict(kw_start)
 
@@ -38,72 +44,76 @@ class TestTileLoader(TestLoader):
         # level, rect = 1, (-180,-90,181,91) # fail
         # level, rect = 1, (-180,-90,180,90) # ok
         # level, rect = 7, (4.7,47.4 , 16.3,55.2)
-        level, rect = 1, (4.7,47.4 , 16.3,55.2) # test interrupt
+        level, rect = 1, (4.7, 47.4, 16.3, 55.2)  # test interrupt
 
-        kw.update(dict(  
-            rect=rect,
-            level=level,
-            tile_schema=schema
-            ))
+        kw.update(dict(rect=rect, level=level, tile_schema=schema))
         self.subtest_load_layer(conn_info, meta, feat_cnt, n_parallel, **kw)
-        
+
     def subtest_load_layer(self, conn_info, meta, feat_cnt, n_parallel, **kw_start):
         limit = kw_start.get("limit", 30000)
         layer = None
-        with self.subTest(conn_info=conn_info.get_xyz_space(), #meta=meta, 
-        feat_cnt=feat_cnt,n_parallel=n_parallel,**kw_start):
+        with self.subTest(
+            conn_info=conn_info.get_xyz_space(),  # meta=meta,
+            feat_cnt=feat_cnt,
+            n_parallel=n_parallel,
+            **kw_start
+        ):
             loader = self._make_load_controller(n_parallel)
 
             layer = self._load_layer(loader, conn_info, meta, **kw_start)
             self._assert_layer(layer, feat_cnt, limit)
 
-        if self.flag_canvas: self._wait_async()
+        if self.flag_canvas:
+            self._wait_async()
         return layer
-     
+
     def _assert_layer(self, layer, feat_cnt, limit):
         feat_cnt_layer = layer.get_feat_cnt()
         self._log_debug("Feature count", feat_cnt_layer)
-        if feat_cnt is None: return
+        if feat_cnt is None:
+            return
         with self.subTest(actual_cnt=feat_cnt_layer):
-            self.assertGreaterEqual(feat_cnt_layer, limit, "check feat_cnt lower bound")  
+            self.assertGreaterEqual(feat_cnt_layer, limit, "check feat_cnt lower bound")
             self.assertLessEqual(feat_cnt_layer, feat_cnt, "check feat_cnt upper bound")
             self.assertEqual(feat_cnt_layer, feat_cnt, "check exact feat_cnt")
+
     def _make_load_controller(self, n_parallel):
         loader = TileLayerLoader(network, n_parallel=n_parallel)
-        
+
         for f in loader.get_lst_fun():
             pass
             # self._log_debug("lst_fun", f)
             # f.signal.results.connect(self._log_debug)
             # f.signal.results.connect( self._add_output)
 
-        loader.signal.finished.connect( self._stop_async)
-        loader.signal.error.connect( self._handle_error)
-        loader.signal.error.connect( self._add_output)
+        loader.signal.finished.connect(self._stop_async)
+        loader.signal.error.connect(self._handle_error)
+        loader.signal.error.connect(self._add_output)
         return loader
+
     def _split_rect(self, rect_all, n_x=5, n_y=5):
         step_x = (rect_all[2] - rect_all[0]) / n_x
         step_y = (rect_all[3] - rect_all[1]) / n_y
 
-        lst_x0 = [rect_all[0] + i*step_x for i in range(n_x)]
+        lst_x0 = [rect_all[0] + i * step_x for i in range(n_x)]
         lst_x1 = lst_x0[1:] + [rect_all[2]]
-        lst_y0 = [rect_all[1] + i*step_y for i in range(n_y)]
+        lst_y0 = [rect_all[1] + i * step_y for i in range(n_y)]
         lst_y1 = lst_y0[1:] + [rect_all[3]]
-        lst_rect = [(x0,y0,x1,y1) 
-        for x0,x1 in zip(lst_x0, lst_x1)
-        for y0,y1 in zip(lst_y0, lst_y1)
+        lst_rect = [
+            (x0, y0, x1, y1) for x0, x1 in zip(lst_x0, lst_x1) for y0, y1 in zip(lst_y0, lst_y1)
         ]
         return lst_rect
+
     def _load_layer(self, loader, conn_info, meta, **kw_start):
         self.canvas = self.canvas_init()
 
-        rect,level,tile_schema = [kw_start[k] for k in ["rect","level","tile_schema"]]
+        rect, level, tile_schema = [kw_start[k] for k in ["rect", "level", "tile_schema"]]
 
         # for i, rect in enumerate(self._split_rect(rect,2,2)):
-        
-        for i,limit in enumerate([10,20,30,40]):
+
+        for i, limit in enumerate([10, 20, 30, 40]):
             self._log_debug(rect)
-            kw_start["tile_ids"] = tile_utils.bboxToListColRow(*rect,level,tile_schema)
+            kw_start["tile_ids"] = tile_utils.bboxToListColRow(*rect, level, tile_schema)
             kw_start["limit"] = limit
             if not i:
                 loader.start(conn_info, meta, **kw_start)
@@ -111,15 +121,16 @@ class TestTileLoader(TestLoader):
                 loader.restart(conn_info, meta, **kw_start)
 
             # self._process_async()
-            # import time 
+            # import time
             # time.sleep(1)
             # self._process_async()
 
             # QTimer.singleShot(100, self._stop_async) # early interrupt
             self._wait_async()
-            
+
             lst_layer = list(loader.layer.iter_layer())
-            if not lst_layer: continue
+            if not lst_layer:
+                continue
 
             if self.flag_canvas:
                 self.canvas.setLayers(lst_layer)
@@ -127,7 +138,7 @@ class TestTileLoader(TestLoader):
         return loader.layer
 
     def _wait_async(self):
-        try: 
+        try:
             super()._wait_async()
         except AllErrorsDuringTest as e:
             lst_err = e.args[0]
@@ -137,10 +148,12 @@ class TestTileLoader(TestLoader):
 
     def canvas_init(self):
         from test import mock_iface
+
         iface = mock_iface.make_iface_canvas(self)
         canvas = iface.mapCanvas()
         canvas.closed.connect(self._stop_async)
-        if self.flag_canvas: canvas.show()
+        if self.flag_canvas:
+            canvas.show()
         return canvas
 
     def canvas_zoom_to_layer(self, canvas, vlayer):
@@ -151,30 +164,32 @@ class TestTileLoader(TestLoader):
         canvas.refresh()
         canvas.waitWhileRendering()
 
-for n_parallel in [1,2,4,8]:
-    add_test_fn_params(TestTileLoader,"_test_load_small_layer",n_parallel=n_parallel)
-    add_test_fn_params(TestTileLoader,"_test_load_large_layer",n_parallel=n_parallel)
-    for limit in [100,250,1000,100000]:
-        add_test_fn_params(TestTileLoader,"_test_load_small_layer",n_parallel=n_parallel, limit=limit)
-        add_test_fn_params(TestTileLoader,"_test_load_large_layer",n_parallel=n_parallel, limit=limit)
 
+for n_parallel in [1, 2, 4, 8]:
+    add_test_fn_params(TestTileLoader, "_test_load_small_layer", n_parallel=n_parallel)
+    add_test_fn_params(TestTileLoader, "_test_load_large_layer", n_parallel=n_parallel)
+    for limit in [100, 250, 1000, 100000]:
+        add_test_fn_params(
+            TestTileLoader, "_test_load_small_layer", n_parallel=n_parallel, limit=limit
+        )
+        add_test_fn_params(
+            TestTileLoader, "_test_load_large_layer", n_parallel=n_parallel, limit=limit
+        )
 
 
 if __name__ == "__main__":
     import sys
+
     if "--canvas" in sys.argv:
         TestTileLoader.flag_canvas = True
         sys.argv.remove("--canvas")
 
-    
     # unittest.main()
     tests = [
         "TestTileLoader.test_load_small_layer_n_parallel_2_limit_100",
         "TestTileLoader.test_load_small_layer_n_parallel_2_limit_250",
-
         # "TestTileLoader.test_load_small_layer_n_parallel_2_limit_100000",
         # "TestTileLoader.test_load_large_layer_n_parallel_2_limit_1000",
-
         # "TestTileLoader.test_load_large_layer_n_parallel_2_limit_100",
         # "TestTileLoader.test_load_small_layer_n_parallel_4_limit_100000", # large limit: test retry
         # "TestTileLoader.test_load_small_layer_n_parallel_4_limit_100",
@@ -183,5 +198,4 @@ if __name__ == "__main__":
         # "TestTileLoader.test_load_small_layer_n_parallel_8",
     ]
     # unittest.main(defaultTest = tests, failfast=True) # will not run all subtest
-    unittest.main(defaultTest = tests)
-    
+    unittest.main(defaultTest=tests)

--- a/test/test_tile_utils.py
+++ b/test/test_tile_utils.py
@@ -11,9 +11,15 @@ import json
 import random
 import numpy as np
 
-from test.utils import (BaseTestAsync, TestFolder, format_long_args,
-                        len_of_struct, len_of_struct_sorted, flatten,
-                        format_map_fields)
+from test.utils import (
+    BaseTestAsync,
+    TestFolder,
+    format_long_args,
+    len_of_struct,
+    len_of_struct_sorted,
+    flatten,
+    format_map_fields,
+)
 
 from qgis.core import QgsFields, QgsVectorLayer
 from qgis.testing import unittest
@@ -22,54 +28,55 @@ from XYZHubConnector.xyz_qgis.layer import tile_utils
 
 # import unittest
 class TestTileUtils(BaseTestAsync):
-
     @unittest.skip("skip unused")
     def test_bbox_quadkey(self):
         tol = 1e-9
         tolY = 1e-3
         rect_all = (-180, -90, 180, 90)
-        rect_lowerL = (-180, -90, 0-tol, 0-tolY)
-        rect_lowerR = (0, -90, 180, 0-tolY)
-        rect_upperL = (-180, 0, 0-tol, 90)
+        rect_lowerL = (-180, -90, 0 - tol, 0 - tolY)
+        rect_lowerR = (0, -90, 180, 0 - tolY)
+        rect_upperL = (-180, 0, 0 - tol, 90)
         rect_upperR = (0, 0, 180, 90)
 
         lst = tile_utils.bboxToListQuadkey(*rect_all, 1)
-        self.assertEqual(
-            sorted(tile_utils.bboxToListQuadkey(*rect_all, 1)), 
-            ['0', '1', '2', '3'])
+        self.assertEqual(sorted(tile_utils.bboxToListQuadkey(*rect_all, 1)), ["0", "1", "2", "3"])
 
         self.assertEqual(
-            [tile_utils.bboxToListQuadkey(*rect, 1)
-            for rect in [rect_upperL, rect_upperR, rect_lowerR, rect_lowerL]],
-            [['0'], ['1'], ['2'], ['3']]
-            )
+            [
+                tile_utils.bboxToListQuadkey(*rect, 1)
+                for rect in [rect_upperL, rect_upperR, rect_lowerR, rect_lowerL]
+            ],
+            [["0"], ["1"], ["2"], ["3"]],
+        )
 
     def test_bbox_row_col_web(self):
         tol = 1e-9
         tolY = 1e-3
         rect_all = (-180, -90, 180, 90)
-        rect_lowerL = (-180, -90, 0-tol, 0-tolY)
-        rect_lowerR = (0, -90, 180, 0-tolY)
-        rect_upperL = (-180, 0+tol, 0-tol, 90)
-        rect_upperR = (0, 0+tol, 180, 90)
+        rect_lowerL = (-180, -90, 0 - tol, 0 - tolY)
+        rect_lowerR = (0, -90, 180, 0 - tolY)
+        rect_upperL = (-180, 0 + tol, 0 - tol, 90)
+        rect_upperR = (0, 0 + tol, 180, 90)
 
         for rect in [rect_all, rect_lowerL, rect_lowerR, rect_upperL, rect_upperR]:
             self.assertEqual(
-                sorted(tile_utils.bboxToListColRow(*rect, 0, schema="web")), 
-                ['0_0_0'])
-            
-        self.assertEqual(
-            sorted(tile_utils.bboxToListColRow(*rect_all, 1, schema="web")), 
-            ['1_0_0', '1_0_1', '1_1_0', '1_1_1'])
-            
-        self.assertEqual(
-            [tile_utils.bboxToListColRow(*rect, 1, schema="web")
-            for rect in [rect_upperL, rect_lowerL, rect_upperR, rect_lowerR]], 
-            [['1_0_0'], ['1_0_1'], ['1_1_0'], ['1_1_1']])
+                sorted(tile_utils.bboxToListColRow(*rect, 0, schema="web")), ["0_0_0"]
+            )
 
         self.assertEqual(
-            len(tile_utils.bboxToListColRow(*rect_all, 2, schema="web")),
-            16)
+            sorted(tile_utils.bboxToListColRow(*rect_all, 1, schema="web")),
+            ["1_0_0", "1_0_1", "1_1_0", "1_1_1"],
+        )
+
+        self.assertEqual(
+            [
+                tile_utils.bboxToListColRow(*rect, 1, schema="web")
+                for rect in [rect_upperL, rect_lowerL, rect_upperR, rect_lowerR]
+            ],
+            [["1_0_0"], ["1_0_1"], ["1_1_0"], ["1_1_1"]],
+        )
+
+        self.assertEqual(len(tile_utils.bboxToListColRow(*rect_all, 2, schema="web")), 16)
 
         # print(
         #     (tile_utils.bboxToListColRow(*rect_all, 2, schema="web")),
@@ -80,87 +87,70 @@ class TestTileUtils(BaseTestAsync):
         tol = 1e-9
         tolY = 1e-3
         rect_all = (-180, -90, 180, 90)
-        rect_lowerL = (-180, -90, 0-tol, 0-tolY)
-        rect_lowerR = (0, -90, 180, 0-tolY)
-        rect_upperL = (-180, 0, 0-tol, 90)
+        rect_lowerL = (-180, -90, 0 - tol, 0 - tolY)
+        rect_lowerR = (0, -90, 180, 0 - tolY)
+        rect_upperL = (-180, 0, 0 - tol, 90)
         rect_upperR = (0, 0, 180, 90)
 
         for rect in [rect_all, rect_lowerL, rect_lowerR, rect_upperL, rect_upperR]:
-            self.assertEqual(
-                sorted(tile_utils.bboxToListColRow(*rect, 0)), 
-                ['0_0_0'])
-            
-        self.assertEqual(
-            sorted(tile_utils.bboxToListColRow(*rect_all, 1)), 
-            ['1_0_0', '1_1_0'])
+            self.assertEqual(sorted(tile_utils.bboxToListColRow(*rect, 0)), ["0_0_0"])
+
+        self.assertEqual(sorted(tile_utils.bboxToListColRow(*rect_all, 1)), ["1_0_0", "1_1_0"])
         for rect in [rect_lowerL, rect_upperL]:
-            self.assertEqual(
-                sorted(tile_utils.bboxToListColRow(*rect, 1)), 
-                ['1_0_0'])
+            self.assertEqual(sorted(tile_utils.bboxToListColRow(*rect, 1)), ["1_0_0"])
         for rect in [rect_lowerR, rect_upperR]:
-            self.assertEqual(
-                sorted(tile_utils.bboxToListColRow(*rect, 1)), 
-                ['1_1_0'])
+            self.assertEqual(sorted(tile_utils.bboxToListColRow(*rect, 1)), ["1_1_0"])
 
         self.assertEqual(
-            sorted(tile_utils.bboxToListColRow(*rect_all, 2)), 
-            ['2_0_0', '2_0_1', '2_1_0', '2_1_1', '2_2_0', '2_2_1', '2_3_0', '2_3_1'])
-            
-        self.assertEqual( 
-            sorted(tile_utils.bboxToListColRow(*rect_lowerL , 2)), 
-            ['2_0_0', '2_1_0'])
-        self.assertEqual( 
-            sorted(tile_utils.bboxToListColRow(*rect_lowerR , 2)), 
-            ['2_2_0', '2_3_0'])
-        self.assertEqual( 
-            sorted(tile_utils.bboxToListColRow(*rect_upperL , 2)), 
-            ['2_0_1', '2_1_1'])
-        self.assertEqual( 
-            sorted(tile_utils.bboxToListColRow(*rect_upperR , 2)), 
-            ['2_2_1', '2_3_1'])
+            sorted(tile_utils.bboxToListColRow(*rect_all, 2)),
+            ["2_0_0", "2_0_1", "2_1_0", "2_1_1", "2_2_0", "2_2_1", "2_3_0", "2_3_1"],
+        )
+
+        self.assertEqual(sorted(tile_utils.bboxToListColRow(*rect_lowerL, 2)), ["2_0_0", "2_1_0"])
+        self.assertEqual(sorted(tile_utils.bboxToListColRow(*rect_lowerR, 2)), ["2_2_0", "2_3_0"])
+        self.assertEqual(sorted(tile_utils.bboxToListColRow(*rect_upperL, 2)), ["2_0_1", "2_1_1"])
+        self.assertEqual(sorted(tile_utils.bboxToListColRow(*rect_upperR, 2)), ["2_2_1", "2_3_1"])
 
     def print_coord_to_row_col(self):
-        level=1
-        for lon in [-180,-90,0,90,180]:
-            for lat in [-90,-45,0,45,90]:
-                coord = [lon,lat]
+        level = 1
+        for lon in [-180, -90, 0, 90, 180]:
+            for lat in [-90, -45, 0, 45, 90]:
+                coord = [lon, lat]
                 rc = tile_utils.coord_to_row_col(coord, level)
-                print(level,coord,"\t",rc)
+                print(level, coord, "\t", rc)
 
     # @unittest.skip("skip")
     def test_coord_to_row_col(self):
         # self.print_coord_to_row_col()
-        for schema, expected in [
-            ["here", [547589, 407779]],
-            ["web", [547589, 692956]]
-        ]:
+        for schema, expected in [["here", [547589, 407779]], ["web", [547589, 692956]]]:
             with self.subTest(schema=schema):
                 level = 20
-                coord = [8,50]
+                coord = [8, 50]
                 rc = tile_utils.coord_to_row_col(coord, level, schema)
-                print(level,coord,rc,schema)
+                print(level, coord, rc, schema)
                 # self.assertEqual(list(reversed(rc)), [547589, 355619]) # from geotool # rc vs xy
-                self.assertEqual(list(reversed(rc)), expected) # 2^(n-1), reversed index # rc vs xy
+                self.assertEqual(
+                    list(reversed(rc)), expected
+                )  # 2^(n-1), reversed index # rc vs xy
 
     def test_coord_from_percent(self):
-        avg = lambda lst: sum(x for x in lst)/len(lst)
-        abs_avg = lambda lst: sum(abs(x) for x in lst)/len(lst)
+        avg = lambda lst: sum(x for x in lst) / len(lst)
+        abs_avg = lambda lst: sum(abs(x) for x in lst) / len(lst)
         level = 1
         n_coord = 20
-        lst_percent = np.linspace(0,1,n_coord)
-        lst_x = [tile_utils.coord_from_percent(0,x,level)[0] for x in lst_percent]
+        lst_percent = np.linspace(0, 1, n_coord)
+        lst_x = [tile_utils.coord_from_percent(0, x, level)[0] for x in lst_percent]
         max_x = 180
-        lst_y = [tile_utils.coord_from_percent(x,0,level)[1] for x in lst_percent]
+        lst_y = [tile_utils.coord_from_percent(x, 0, level)[1] for x in lst_percent]
         max_y = 90
 
         lst_debug_avg = [
             "\t" + "avg(lst_x), abs_avg(lst_x), avg(lst_y), abs_avg(lst_y)",
-            "actual: \t" + "\t".join(map("{:.2f}".format, [
-                avg(lst_x), abs_avg(lst_x), avg(lst_y), abs_avg(lst_y)
-            ])),
-            "expected: \t" + "\t".join(map("{:.2f}".format,[
-                0, max_x/2, 0, max_y/2
-            ]))
+            "actual: \t"
+            + "\t".join(
+                map("{:.2f}".format, [avg(lst_x), abs_avg(lst_x), avg(lst_y), abs_avg(lst_y)])
+            ),
+            "expected: \t" + "\t".join(map("{:.2f}".format, [0, max_x / 2, 0, max_y / 2])),
         ]
         # print("\n".join(lst_debug_avg))
         try:
@@ -168,24 +158,35 @@ class TestTileUtils(BaseTestAsync):
             self.assertEqual(-max_x, min(lst_x))
             self.assertEqual(max(lst_y), max_y)
             self.assertEqual(-max_y, min(lst_y))
-            self.assertAlmostEqual(avg(lst_x), 0, 
-                msg="x coordinates not average to 0")
-            self.assertAlmostEqual(abs_avg(lst_x), max_x/2, delta=max_x*0.05, 
-                msg="abs x coordinates not average to %s"%(max_x/2))
-            self.assertAlmostEqual(avg(lst_y), 0, 
-                msg="y coordinates not average to 0")
-            self.assertAlmostEqual(abs_avg(lst_y), max_y/2, delta=max_y*0.05, 
-                msg="abs y coordinates not average to %s"%(max_y/2))
+            self.assertAlmostEqual(avg(lst_x), 0, msg="x coordinates not average to 0")
+            self.assertAlmostEqual(
+                abs_avg(lst_x),
+                max_x / 2,
+                delta=max_x * 0.05,
+                msg="abs x coordinates not average to %s" % (max_x / 2),
+            )
+            self.assertAlmostEqual(avg(lst_y), 0, msg="y coordinates not average to 0")
+            self.assertAlmostEqual(
+                abs_avg(lst_y),
+                max_y / 2,
+                delta=max_y * 0.05,
+                msg="abs y coordinates not average to %s" % (max_y / 2),
+            )
         except Exception as e:
             linesep = "\n "
-            debug_coord = ("percent" + "\t" + "coord" + linesep +
-                linesep.join(map(lambda a: "{:.2f} \t{:.2f} {:.2f}".format(*a), 
-                zip(lst_percent, lst_x, lst_y)))
+            debug_coord = (
+                "percent"
+                + "\t"
+                + "coord"
+                + linesep
+                + linesep.join(
+                    map(
+                        lambda a: "{:.2f} \t{:.2f} {:.2f}".format(*a),
+                        zip(lst_percent, lst_x, lst_y),
+                    )
                 )
-            e.args = (linesep.join([
-                e.args[0], *lst_debug_avg, debug_coord
-                ]), 
-                *e.args[1:])
+            )
+            e.args = (linesep.join([e.args[0], *lst_debug_avg, debug_coord]), *e.args[1:])
             raise e
 
     def test_extent_from_row_col(self):
@@ -194,32 +195,47 @@ class TestTileUtils(BaseTestAsync):
         for schema in ["here", "web"]:
             lst_msg = list()
             lst_check = list()
-            for lon in [-180,-90,0,90,180]:
-                for lat in [-90,-45,0,45,90]:
-                    coord = [lon,lat]
+            for lon in [-180, -90, 0, 90, 180]:
+                for lat in [-90, -45, 0, 45, 90]:
+                    coord = [lon, lat]
                     r, c = tile_utils.coord_to_row_col(coord, level, schema)
                     extent = tile_utils.extent_from_row_col(r, c, level, schema)
-                    check = (
-                        (extent[0] <= coord[0] <= extent[2] ) and
-                        (extent[1] <= coord[1] <= extent[3] )
+                    check = (extent[0] <= coord[0] <= extent[2]) and (
+                        extent[1] <= coord[1] <= extent[3]
+                    )
+                    lst_msg.append(
+                        " ".join(
+                            map(
+                                str,
+                                [
+                                    level,
+                                    [r, c],
+                                    "\t",
+                                    coord,
+                                    "\t",
+                                    extent,
+                                    "\t",
+                                    "Ok" if check else "Fail",
+                                ],
+                            )
                         )
-                    lst_msg.append(" ".join(map(str,
-                        [level,[r,c],"\t",coord,"\t",extent,"\t",
-                        "Ok" if check else "Fail"
-                        ])))
+                    )
                     lst_check.append(check)
 
-            self.assertTrue(all(lst_check), 
-                "schema: %s. " %(schema) +
-                "Converted extent does not cover input coord" +
-                linesep + linesep.join(lst_msg))
+            self.assertTrue(
+                all(lst_check),
+                "schema: %s. " % (schema)
+                + "Converted extent does not cover input coord"
+                + linesep
+                + linesep.join(lst_msg),
+            )
 
     @unittest.skip("skip example")
     def test_example_1(self):
-        level=6
-        for coord in [[-136.7, -61.5],[-136.7, 61.5], [-92.9, -34.0]]:
+        level = 6
+        for coord in [[-136.7, -61.5], [-136.7, 61.5], [-92.9, -34.0]]:
             rc = tile_utils.coord_to_row_col(coord, level)
-            print(level,coord,rc)
+            print(level, coord, rc)
 
     @unittest.skip("skip unused")
     def test_bbox_to_quad_tile(self):
@@ -228,26 +244,24 @@ class TestTileUtils(BaseTestAsync):
 
     def _test_bbox_to_quad_tile(self, fn):
         # https://wiki.openstreetmap.org/wiki/Zoom_levels
-        rect= (-180,-90,180,90)
+        rect = (-180, -90, 180, 90)
         for level in range(2):
             with self.subTest(level=level, rect=rect):
-                lst = tile_utils.bboxToListQuadkey(*rect,level)
-                lst2 = tile_utils.bboxToListColRow(*rect,level)
+                lst = tile_utils.bboxToListQuadkey(*rect, level)
+                lst2 = tile_utils.bboxToListColRow(*rect, level)
                 print(level, len(lst), len(lst2), lst, lst2)
 
                 # lst = fn(*rect,level)
                 # n_tiles = 2**(2*level)
                 # print(level, len(lst), len(lst2), n_tiles, "diff: %s"%(n_tiles - len(lst)))
                 # # self.assertEqual(len(lst), n_tiles, "diff: %s"%(n_tiles - len(lst)))
-                
 
 
-        
 if __name__ == "__main__":
     unittest.main()
 
     # tests = [
-        
+
     # ]
     # # unittest.main(defaultTest = tests, failfast=True) # will not run all subtest
     # unittest.main(defaultTest = tests)

--- a/test/test_token_model.py
+++ b/test/test_token_model.py
@@ -13,8 +13,11 @@ from test.utils import BaseTestAsync, TestFolder
 from qgis.PyQt.QtGui import QStandardItem
 from qgis.testing import unittest
 from XYZHubConnector.xyz_qgis.models.token_model import (
-    ConfigParserMixin, TokenModel,
-    ServerModel, make_config_parser)
+    ConfigParserMixin,
+    TokenModel,
+    ServerModel,
+    make_config_parser,
+)
 
 
 # import unittest
@@ -26,19 +29,23 @@ class TestTokenModel(BaseTestAsync):
         ini = folder.fullpath("token.ini")
         token_model = TokenModel(ini)
         token_model.load_from_file()
-        
+
         input_token_info = [dict(name="somename", token="helloworldtoken")]
         for token_info in input_token_info:
-            token_model.appendRow([QStandardItem(t)  
-                for t in token_model.items_from_data(token_info)
-            ])
+            token_model.appendRow(
+                [QStandardItem(t) for t in token_model.items_from_data(token_info)]
+            )
         token_model.submit_cache()
         txt = folder.load("token.ini")
 
-        self.assertEqual('[PRD]\nhelloworldtoken,somename\n\n', txt.replace("\r\n","\n"), "ini does not match expected")
+        self.assertEqual(
+            "[PRD]\nhelloworldtoken,somename\n\n",
+            txt.replace("\r\n", "\n"),
+            "ini does not match expected",
+        )
 
     def test_load_old_config(self):
-        """ load old config should results in new config that is backward-compatible. 
+        """load old config should results in new config that is backward-compatible.
         Expected output contains the old server env and the newly migrated server url
         """
         txt = "[PRD]\nA0\nA1,\nA2,A2\n\n[B]\nB0\n\n"
@@ -51,19 +58,27 @@ class TestTokenModel(BaseTestAsync):
 
         url = "https://hub-server-prd.com/hub"
         token_model.set_default_servers(dict(PRD=url))
-        self.assertEqual({
-            'PRD': [{'token': 'A0'}, {'token': 'A1', 'name': ''}, {'token': 'A2', 'name': 'A2'}],
-            url: [{'token': 'A0'}, {'token': 'A1', 'name': ''}, {'token': 'A2', 'name': 'A2'}],
-            'B': [{'token': 'B0'}], 
+        self.assertEqual(
+            {
+                "PRD": [
+                    {"token": "A0"},
+                    {"token": "A1", "name": ""},
+                    {"token": "A2", "name": "A2"},
+                ],
+                url: [{"token": "A0"}, {"token": "A1", "name": ""}, {"token": "A2", "name": "A2"}],
+                "B": [{"token": "B0"}],
             },
-            token_model.to_dict()
+            token_model.to_dict(),
         )
 
         folder.save("token.ini", "")
         token_model.submit_cache()
         out = folder.load("token.ini")
-        self.assertEqual(txt + "[{}]\nA0,\nA1,\nA2,A2\n\n".format(url),
-            out.replace("\r\n","\n"), "ini does not match expected")
+        self.assertEqual(
+            txt + "[{}]\nA0,\nA1,\nA2,A2\n\n".format(url),
+            out.replace("\r\n", "\n"),
+            "ini does not match expected",
+        )
 
     def test_set_server(self):
         folder = TestFolder()
@@ -73,7 +88,9 @@ class TestTokenModel(BaseTestAsync):
         token_model.load_from_file()
         folder.save("token.ini", "")
 
-        server_env_url = dict(PRD="https://hub-server-prd.com/hub",CIT="https://hub-server-cit.com/hub")
+        server_env_url = dict(
+            PRD="https://hub-server-prd.com/hub", CIT="https://hub-server-cit.com/hub"
+        )
         token_model.set_default_servers(server_env_url)
 
         # load data via ui functions
@@ -85,25 +102,25 @@ class TestTokenModel(BaseTestAsync):
 
             token_model.set_server(url)
             for token_info in lst:
-                token_model.appendRow([QStandardItem(t)  
-                    for t in token_model.items_from_data(token_info)
-                ])
+                token_model.appendRow(
+                    [QStandardItem(t) for t in token_model.items_from_data(token_info)]
+                )
             token_model.submit_cache()
 
         self.assertMultiInput(
-            input_token_info, 
-            [
-            token_model.to_dict(),
-            token_model.parser.get_config()
-            ],
+            input_token_info,
+            [token_model.to_dict(), token_model.parser.get_config()],
         )
         out = folder.load("token.ini")
-        self.assertEqual('[https://hub-server-prd.com/hub]\nhelloworldtoken,token for PRD\n\n[https://hub-server-cit.com/hub]\nhelloworldtoken,token for CIT\n\n',
-            out.replace("\r\n","\n"), "ini does not match expected")
+        self.assertEqual(
+            "[https://hub-server-prd.com/hub]\nhelloworldtoken,token for PRD\n\n[https://hub-server-cit.com/hub]\nhelloworldtoken,token for CIT\n\n",
+            out.replace("\r\n", "\n"),
+            "ini does not match expected",
+        )
 
     def test_load_mixed_old_new_config(self):
-        """ test loading config with both old server env and new server url. 
-        Expected the old server env remains unchanged for backward-compatible, 
+        """test loading config with both old server env and new server url.
+        Expected the old server env remains unchanged for backward-compatible,
         the new server url got updated
         """
         url = "https://hub-server-prd.com/hub"
@@ -118,28 +135,35 @@ class TestTokenModel(BaseTestAsync):
 
         server_env_url = dict(PRD=url)
         token_model.set_default_servers(server_env_url)
-        
+
         self.assertMultiInput(
             {
-            'PRD': [{'token': 'A0'}, {'token': 'A1', 'name': ''}, {'token': 'A2', 'name': 'A2'}], 
-            url: [{'token': 'B0', 'name': ''}, {'token': 'B1', 'name': ''}],
+                "PRD": [
+                    {"token": "A0"},
+                    {"token": "A1", "name": ""},
+                    {"token": "A2", "name": "A2"},
+                ],
+                url: [{"token": "B0", "name": ""}, {"token": "B1", "name": ""}],
             },
-            [
-            token_model.to_dict(),
-            token_model.parser.get_config()
-            ],
+            [token_model.to_dict(), token_model.parser.get_config()],
         )
-        
+
         token_model.set_server(url)
-        token_model.appendRow([QStandardItem(t) 
-            for t in token_model.items_from_data(dict(token="B2",name=""))])
+        token_model.appendRow(
+            [QStandardItem(t) for t in token_model.items_from_data(dict(token="B2", name=""))]
+        )
         token_model.submit_cache()
         out = folder.load("token.ini")
-        self.assertEqual(txt.replace("B1,","B1,\nB2,"), out.replace("\r\n","\n"), "ini does not match expected")
+        self.assertEqual(
+            txt.replace("B1,", "B1,\nB2,"),
+            out.replace("\r\n", "\n"),
+            "ini does not match expected",
+        )
+
 
 class TestConfigParserMixin(BaseTestAsync):
     def test_deserialize_token(self):
-        parser = ConfigParserMixin("","", serialize_keys=("token","name"))
+        parser = ConfigParserMixin("", "", serialize_keys=("token", "name"))
         self.assertMultiInput(
             dict(token="onlytoken"),
             [
@@ -147,32 +171,32 @@ class TestConfigParserMixin(BaseTestAsync):
                 parser.deserialize(" onlytoken"),
                 parser.deserialize("onlytoken "),
                 parser.deserialize("onlytoken \t"),
-            ]
+            ],
         )
         self.assertMultiInput(
             dict(token="onlytoken", name=""),
             [
-            parser.deserialize("onlytoken,"),
-            parser.deserialize("onlytoken , "),
+                parser.deserialize("onlytoken,"),
+                parser.deserialize("onlytoken , "),
             ],
         )
         self.assertMultiInput(
             dict(token="helloworldtoken", name="nameoftoken"),
             [
-            parser.deserialize("helloworldtoken,nameoftoken"),
-            parser.deserialize("helloworldtoken, nameoftoken"),
-            parser.deserialize("helloworldtoken ,nameoftoken"),
-            parser.deserialize(" helloworldtoken , nameoftoken "),
+                parser.deserialize("helloworldtoken,nameoftoken"),
+                parser.deserialize("helloworldtoken, nameoftoken"),
+                parser.deserialize("helloworldtoken ,nameoftoken"),
+                parser.deserialize(" helloworldtoken , nameoftoken "),
             ],
         )
         self.assertMultiInput(
             dict(token="helloworldtoken", name="name,with,comma"),
             [
-            parser.deserialize("helloworldtoken,name,with,comma"),
-            parser.deserialize("helloworldtoken, name,with,comma"),
+                parser.deserialize("helloworldtoken,name,with,comma"),
+                parser.deserialize("helloworldtoken, name,with,comma"),
             ],
         )
-            
+
         self.assertEqual(
             dict(token="helloworldtoken", name="name,with space comma"),
             parser.deserialize("helloworldtoken,name,with space comma"),
@@ -182,7 +206,7 @@ class TestConfigParserMixin(BaseTestAsync):
             dict(token="helloworldtoken", name="name,with space comma"),
             parser.deserialize("helloworldtoken,name,with space comma"),
         )
-            
+
         self.assertEqual(
             dict(token="helloworldtoken", name="name,with, space comma"),
             parser.deserialize("helloworldtoken, name,with, space comma"),
@@ -190,107 +214,92 @@ class TestConfigParserMixin(BaseTestAsync):
 
         self.assertEqual(
             dict(token="+*~#-.! = e23"),
-            parser.deserialize("+*~#-.! = e23"), "deserialize special char failed"
+            parser.deserialize("+*~#-.! = e23"),
+            "deserialize special char failed",
         )
         self.assertEqual(
             dict(token=r"!\"#$%&'()*+-./:;<=>?@[\]^_`{|}~"),
-            parser.deserialize(r"!\"#$%&'()*+-./:;<=>?@[\]^_`{|}~"), "deserialize special char failed"
+            parser.deserialize(r"!\"#$%&'()*+-./:;<=>?@[\]^_`{|}~"),
+            "deserialize special char failed",
         )
 
     def test_serialize_token(self):
-        parser = ConfigParserMixin("","", serialize_keys=("token","name"))
+        parser = ConfigParserMixin("", "", serialize_keys=("token", "name"))
 
         self.assertMultiInput(
             "helloworldtoken,name,with space comma",
             [
-            parser.serialize_data(dict(token="helloworldtoken", name="name,with space comma")),
-            parser.serialize_data(dict(token="helloworldtoken \t", name=" name,with space comma ")),
+                parser.serialize_data(dict(token="helloworldtoken", name="name,with space comma")),
+                parser.serialize_data(
+                    dict(token="helloworldtoken \t", name=" name,with space comma ")
+                ),
             ],
         )
-            
+
         self.assertMultiInput(
             "helloworldtoken,",
             [
-            parser.serialize_data(dict(token="helloworldtoken")),
+                parser.serialize_data(dict(token="helloworldtoken")),
             ],
         )
         self.assertMultiInput(
             ",namewithouttoken",
             [
-            parser.serialize_data(dict(name="namewithouttoken")),
+                parser.serialize_data(dict(name="namewithouttoken")),
             ],
         )
 
     def test_update_config(self):
-        parser = ConfigParserMixin("",make_config_parser(),serialize_keys=("token","name"))
-        sections = ["A","B"]
-        data = {s: [
-            dict(token="{}{}".format(s,i), name="{}{}".format(s,i)) 
-            for i in range(3)
-            ]
+        parser = ConfigParserMixin("", make_config_parser(), serialize_keys=("token", "name"))
+        sections = ["A", "B"]
+        data = {
+            s: [dict(token="{}{}".format(s, i), name="{}{}".format(s, i)) for i in range(3)]
             for s in sections
         }
         parser.update_config(dict(A=data["A"]))
         parser.update_config(dict(B=data["B"]))
 
         try:
-            self.assertEqual(
-                data,
-                parser.get_config()
-            )
+            self.assertEqual(data, parser.get_config())
 
             data["A"].reverse()
-            self.assertNotEqual(
-                data,
-                parser.get_config()
-            )
+            self.assertNotEqual(data, parser.get_config())
 
             parser.update_config(dict(A=data["A"]))
-            self.assertEqual(
-                data,
-                parser.get_config()
-            )
+            self.assertEqual(data, parser.get_config())
 
             data["B"].clear()
-            self.assertNotEqual(
-                data,
-                parser.get_config()
-            )
+            self.assertNotEqual(data, parser.get_config())
 
             parser.update_config(dict(B=data["B"]))
-            self.assertEqual(
-                data,
-                parser.get_config()
+            self.assertEqual(data, parser.get_config())
+
+            data.update(
+                {
+                    s: [
+                        dict(token="{}{}".format(s, i), name="{}{}".format(s, i)) for i in range(3)
+                    ]
+                    for s in ["C"]
+                }
             )
-            
-            data.update({s: [
-                dict(token="{}{}".format(s,i), name="{}{}".format(s,i)) 
-                for i in range(3)]
-                for s in ["C"]
-            })
-            
+
             parser.update_config(dict(C=data["C"]))
-            self.assertEqual(
-                data,
-                parser.get_config()
-            )
-            
-            data_with_invalid_section = {s: [
-                dict(token="{}{}".format(s,i), name="{}{}".format(s,i)) 
-                for i in range(3)]
-                for s in [" ",""]
+            self.assertEqual(data, parser.get_config())
+
+            data_with_invalid_section = {
+                s: [dict(token="{}{}".format(s, i), name="{}{}".format(s, i)) for i in range(3)]
+                for s in [" ", ""]
             }
             parser.update_config(data_with_invalid_section)
             self.assertEqual(
-                data,
-                parser.get_config(), "data with invalid section is not rejected"
+                data, parser.get_config(), "data with invalid section is not rejected"
             )
-            
+
             # # TODO: test invalid token in final token model
             # # writer does not know what is an invalid data (empty token or name)
             # # the token model should know
             # data_with_invalid_token = {s: [
-            #     dict(token="", name="{}{}".format(s,i)) 
+            #     dict(token="", name="{}{}".format(s,i))
             #     for i in range(3)]
             #     for s in ["D"]
             # }
@@ -313,15 +322,13 @@ class TestConfigParserMixin(BaseTestAsync):
         folder.save("token.ini", "")
         ini = folder.fullpath("token.ini")
         cfg = make_config_parser()
-        parser = ConfigParserMixin(ini, cfg, serialize_keys=("token","name"))
-        
+        parser = ConfigParserMixin(ini, cfg, serialize_keys=("token", "name"))
+
         bad_sections = [" "]
-        ok_sections = ["A","B"] 
+        ok_sections = ["A", "B"]
         sections = ok_sections + bad_sections
-        data = {s: [
-            dict(token="{}{}".format(s,i), name="{}{}".format(s,i)) 
-            for i in range(3)
-            ]
+        data = {
+            s: [dict(token="{}{}".format(s, i), name="{}{}".format(s, i)) for i in range(3)]
             for s in sections
         }
         txt = "[A]\nA0,A0\nA1,A1\nA2,A2\n\n[B]\nB0,B0\nB1,B1\nB2,B2\n\n"
@@ -336,7 +343,7 @@ class TestConfigParserMixin(BaseTestAsync):
                 cfg.sections(),
             )
             self._test_ini_valid_sections(out, ok_sections)
-            self.assertEqual(txt, out.replace("\r\n","\n"), "ini does not match expected")
+            self.assertEqual(txt, out.replace("\r\n", "\n"), "ini does not match expected")
         except Exception as e:
             self._log_error("sections:", dict(cfg._sections))
             self._log_error("ini content:\n", txt)
@@ -344,13 +351,13 @@ class TestConfigParserMixin(BaseTestAsync):
 
     def test_read_from_file(self):
         txt = "[A]\nA0,A0\nA1,A1\nA2,A2\n\n[B]\nB0,B0\nB1,B1\nB2,B2\n\n"
-        ok_sections = ["A","B"]
+        ok_sections = ["A", "B"]
 
         folder = TestFolder()
         folder.save("token.ini", txt)
         ini = folder.fullpath("token.ini")
         cfg = make_config_parser()
-        parser = ConfigParserMixin(ini, cfg, serialize_keys=("token","name"))
+        parser = ConfigParserMixin(ini, cfg, serialize_keys=("token", "name"))
         parser.read_from_file()
 
         try:
@@ -360,26 +367,28 @@ class TestConfigParserMixin(BaseTestAsync):
             )
 
             data = parser.get_config()
-            self.assertEqual({
-                'A': [
-                    {'token': 'A0', 'name': 'A0'}, 
-                    {'token': 'A1', 'name': 'A1'}, 
-                    {'token': 'A2', 'name': 'A2'}
+            self.assertEqual(
+                {
+                    "A": [
+                        {"token": "A0", "name": "A0"},
+                        {"token": "A1", "name": "A1"},
+                        {"token": "A2", "name": "A2"},
                     ],
-                'B': [
-                    {'token':'B0', 'name': 'B0'}, 
-                    {'token': 'B1', 'name': 'B1'}, 
-                    {'token': 'B2', 'name': 'B2'}
-                    ]
+                    "B": [
+                        {"token": "B0", "name": "B0"},
+                        {"token": "B1", "name": "B1"},
+                        {"token": "B2", "name": "B2"},
+                    ],
                 },
-                data, "loaded config does not match expected"
+                data,
+                "loaded config does not match expected",
             )
 
             folder.save("token.ini", "")
             parser.write_to_file()
             out = folder.load("token.ini")
             self._test_ini_valid_sections(txt, ok_sections)
-            self.assertEqual(txt, out.replace("\r\n","\n"), "ini does not match expected")
+            self.assertEqual(txt, out.replace("\r\n", "\n"), "ini does not match expected")
         except Exception as e:
             self._log_error("sections:", dict(cfg._sections))
             self._log_error("ini content:\n", txt)
@@ -390,24 +399,15 @@ class TestConfigParserMixin(BaseTestAsync):
         self.assertEqual(ok_sections, matched_sections, "unexpected sections found")
 
         self.assertRegex(
-            txt,
-            r"\[({})\]".format("|".join(ok_sections)), "unexpected sections found"
+            txt, r"\[({})\]".format("|".join(ok_sections)), "unexpected sections found"
         )
-        self.assertNotRegex(
-            txt,
-            r"\[[\s]*\]", "sections with empty name found"
-        )
+        self.assertNotRegex(txt, r"\[[\s]*\]", "sections with empty name found")
 
         # invalid name example
-        self.assertRegex(
-            "[ ]",
-            r"\[[\s]*\]", "sections with invalid name found"
-        )
-        self.assertRegex(
-            "[]",
-            r"\[[\s]*\]", "sections with invalid name found"
-        )
-        
+        self.assertRegex("[ ]", r"\[[\s]*\]", "sections with invalid name found")
+        self.assertRegex("[]", r"\[[\s]*\]", "sections with invalid name found")
+
+
 if __name__ == "__main__":
     unittest.main()
     # tests = [

--- a/test/utils.py
+++ b/test/utils.py
@@ -21,34 +21,42 @@ import sys
 import os
 import pprint
 
+
 def get_env(scope, keys):
-    """ usage: get_env(locals(), ["APP_ID", "APP_CODE"]) #globals()
-    """
-    scope.update([ (k, os.environ[k]) for k in keys] )
+    """usage: get_env(locals(), ["APP_ID", "APP_CODE"]) #globals()"""
+    scope.update([(k, os.environ[k]) for k in keys])
+
+
 def env_to_dict(keys):
-    return dict( (k, os.environ[k]) for k in keys)
-    
+    return dict((k, os.environ[k]) for k in keys)
+
+
 class ErrorDuringTest(Exception):
     pass
+
+
 class AllErrorsDuringTest(Exception):
     pass
+
 
 # /tests/src/python/test_db_manager_gpkg.py
 class BaseTestAsync(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.app = start_app()
+
     @classmethod
     def tearDownClass(cls):
         pass
         # cls.app.quit() # useless
         # stop_app() # NameError: name "QGISAPP" is not defined
         # cls.app.exitQgis() # crash when run unittest (all module)
-        # del cls.app 
+        # del cls.app
+
     def setUp(self):
         if isinstance(super(), BaseTestAsync) and hasattr(super(), self._testMethodName):
             self.skipTest("duplicated test")
-            
+
         # self.loop = self.app
         self.loop = QEventLoop()
         self._output = list()
@@ -59,12 +67,13 @@ class BaseTestAsync(unittest.TestCase):
         self._log_debug("Test start. ###################")
 
     def tearDown(self):
-        self._stop_async() # useless ?
+        self._stop_async()  # useless ?
         self._log_debug("Test ended. ################### \n")
         self._log_info("%s: %.3fs" % (self._id(), time.time() - self.startTime))
-        
+
     def _add_output(self, output):
         self._output.append(output)
+
     def output(self, idx=None):
         if idx is None:
             idx = self._idx
@@ -83,79 +92,89 @@ class BaseTestAsync(unittest.TestCase):
 
     def _process_async(self):
         self.loop.processEvents()
-        
+
     def _wait_async(self):
-        t0=time.time()
+        t0 = time.time()
         self.loop.exec_()
 
         self._log_info("%s: wait_async end: %.3fs" % (self._id(), time.time() - t0))
         if self._lst_error:
             raise AllErrorsDuringTest(self._lst_error)
-        
+
     def _make_async_fun(self, fun):
         return AsyncFun(fun)
-        
-    def _log_error(self, *a,**kw):
-        print(*a, file = sys.stderr, **kw)
-    def _log_info(self, *a,**kw):
+
+    def _log_error(self, *a, **kw):
+        print(*a, file=sys.stderr, **kw)
+
+    def _log_info(self, *a, **kw):
         log_truncate(*a, **kw)
-    def _log_debug(self, *a,**kw):
+
+    def _log_debug(self, *a, **kw):
         fn_name = "{}:".format(self._id())
         # fn_name = sys._getframe(1).f_code.co_name
         log_truncate(fn_name, *a, **kw)
+
     def _id(self):
         return self._subtest.id() if self._subtest else self.id()
-        
+
     def assertMultiInput(self, expected, lst_input, msg="multi input"):
         for i, actual in enumerate(lst_input):
-            self.assertEqual(expected, actual, "{} [{}]".format(msg,i))
+            self.assertEqual(expected, actual, "{} [{}]".format(msg, i))
 
-    #unused        
+    # unused
     def assertPairEqual(self, *a):
-        pairs = [a[i:i+2] for i in range(0,len(a),2)]
-        return self.assertEqual( *zip(*pairs ))
+        pairs = [a[i : i + 2] for i in range(0, len(a), 2)]
+        return self.assertEqual(*zip(*pairs))
+
 
 class BaseTestWorkerAsync(BaseTestAsync):
-    
     def setUp(self):
         super().setUp()
-        self.pool = QThreadPool() # .globalInstance() will crash afterward
-        
+        self.pool = QThreadPool()  # .globalInstance() will crash afterward
+
     def tearDown(self):
         self.pool.deleteLater()
         super().tearDown()
-        
+
     def _stop_async(self):
-        if not self.loop.isRunning(): return
+        if not self.loop.isRunning():
+            return
         super()._stop_async()
         self.pool.waitForDone(1)
         self.pool.clear()
+
     def _wait_async(self):
         super()._wait_async()
         self.pool.clear()
+
     def _make_async_fun(self, fun):
-        return WorkerFun( fun, self.pool) 
+        return WorkerFun(fun, self.pool)
 
     # def _log_debug(self, *a,**kw):
     #     print("active thread count", self.pool.activeThreadCount())
     #     super()._log_debug(*a, **kw)
-    
+
+
 def format_long_args(*a, limit=200):
     return " ".join(str(i)[:limit] for i in a)
 
-def log_truncate(*a,**kw):
+
+def log_truncate(*a, **kw):
     # return
     # print(*a,**kw)
     s = format_long_args(*a)
-    print(s,**kw)
+    print(s, **kw)
 
-def log_truncate_timestamp(*a,**kw):
+
+def log_truncate_timestamp(*a, **kw):
     ts = time.strftime("%Y-%m-%dT%H:%M:%S%z")
     log_truncate(ts, *a, **kw)
 
+
 def len_of_struct(x, strict=True):
     if isinstance(x, dict):
-        return dict([(k, len_of_struct(v, strict)) for k, v in x.items()]) 
+        return dict([(k, len_of_struct(v, strict)) for k, v in x.items()])
     elif hasattr(x, "__len__"):
         if not hasattr(x, "__iter__"):
             return len(x)
@@ -163,37 +182,41 @@ def len_of_struct(x, strict=True):
         if len(lst) == 0 or -1 in lst:
             return len(lst)
         return lst if strict else sorted(lst)
-    else: 
+    else:
         return -1
+
+
 def len_of_struct_sorted(x):
     return len_of_struct(x, False)
-def format_map_fields(x):
-    return pprint.pformat(
-        dict((k, [f.names() for f in v])
-        for k,v in x.items()), 
-        compact=True)
-        
 
-def add_test_fn_params(cls,fn_name,*a,**kw):
-    """ Create new test function from function with params (similar to TestCase.subTest() ).
-    Test function name: "test_" + new_fn_name + k1_v1_k2_v2. 
+
+def format_map_fields(x):
+    return pprint.pformat(dict((k, [f.names() for f in v]) for k, v in x.items()), compact=True)
+
+
+def add_test_fn_params(cls, fn_name, *a, **kw):
+    """Create new test function from function with params (similar to TestCase.subTest() ).
+    Test function name: "test_" + new_fn_name + k1_v1_k2_v2.
 
     Example:
-        if fn_name = "_test_fun", kw=dict(a=2) 
+        if fn_name = "_test_fun", kw=dict(a=2)
         -> "test_fun_a_2
-        if fn_name = "_do_fun", kw=dict(a=2) 
+        if fn_name = "_do_fun", kw=dict(a=2)
         -> "test_do_fun_a_2
-        if fn_name = "do_fun", kw=dict(a=2) 
+        if fn_name = "do_fun", kw=dict(a=2)
         -> "test_do_fun_a_2
     """
+
     def _fn(self):
         fun = getattr(self, fn_name)
-        return fun(*a,**kw)
-    s = "_".join("%s_%s"%(k,v) for k,v in kw.items())
-    new_name = ("%s_%s"%(fn_name, s)).strip("_")
+        return fun(*a, **kw)
+
+    s = "_".join("%s_%s" % (k, v) for k, v in kw.items())
+    new_name = ("%s_%s" % (fn_name, s)).strip("_")
     if not new_name.startswith("test"):
         new_name = "test_" + new_name
     setattr(cls, new_name, _fn)
+
 
 # decorator
 def slow_test(func):
@@ -202,16 +225,17 @@ def slow_test(func):
 
 def flatten(lst):
     def _flatten(lst):
-        is_lst = (
-            hasattr(lst, "__len__") and 
-            not isinstance(lst, (str, dict)))
+        is_lst = hasattr(lst, "__len__") and not isinstance(lst, (str, dict))
         if not is_lst:
             yield lst
         else:
             for i in lst:
                 for k in _flatten(i):
                     yield k
+
     return list(_flatten(lst))
+
+
 ######################################
 # io.py
 #####################################
@@ -219,31 +243,40 @@ def flatten(lst):
 import os
 import json
 from XYZHubConnector import config
+
+
 def use_local_tmp_dir():
     TMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tmp")
-    os.makedirs(TMP_DIR,exist_ok=True)
+    os.makedirs(TMP_DIR, exist_ok=True)
     config.TMP_DIR = TMP_DIR
 
+
 use_local_tmp_dir()
+
+
 def make_abs_path(*a):
-    path,_ = os.path.split(__file__)
-    
+    path, _ = os.path.split(__file__)
+
     return os.path.abspath(os.path.join(path, *a))
-    
+
+
 class TestFolder(object):
     def __init__(self, *paths):
-        self.folder = make_abs_path("resources",*paths)
-        os.makedirs(self.folder,exist_ok=True)
+        self.folder = make_abs_path("resources", *paths)
+        os.makedirs(self.folder, exist_ok=True)
+
     def fullpath(self, fname):
         return os.path.join(self.folder, fname)
+
     def load(self, fname):
         infile = os.path.join(self.folder, fname)
-        with open(infile,encoding="utf-8") as f:
+        with open(infile, encoding="utf-8") as f:
             txt = f.read()
         return txt
+
     def save(self, fname, txt):
         outfile = os.path.join(self.folder, fname)
-        with open(outfile,"w",encoding="utf-8") as f:
+        with open(outfile, "w", encoding="utf-8") as f:
             f.write(txt)
 
 
@@ -251,39 +284,47 @@ class LoadInput(object):
     def __init__(self, file, fn_name):
         path, fname = os.path.split(file)
         self.folder = os.path.join(path, "input", fname, fn_name)
-        os.makedirs(self.folder,exist_ok=True)
+        os.makedirs(self.folder, exist_ok=True)
+
     def fullpath(self, fname):
         return os.path.join(self.folder, fname)
+
     def load(self, fname):
         infile = os.path.join(self.folder, fname)
-        with open(infile,encoding="utf-8") as f:
+        with open(infile, encoding="utf-8") as f:
             txt = f.read()
         return txt
+
     def save(self, fname, txt):
         outfile = os.path.join(self.folder, fname)
-        with open(outfile,"w",encoding="utf-8") as f:
+        with open(outfile, "w", encoding="utf-8") as f:
             f.write(txt)
 
-def json_output( out):
+
+def json_output(out):
     return json.loads(json.dumps(out))
+
 
 class SaveOutput(object):
     def __init__(self, file, fn_name):
         path, fname = os.path.split(file)
         self.folder = os.path.join(path, "output", fname, fn_name)
-        os.makedirs(self.folder,exist_ok=True)
+        os.makedirs(self.folder, exist_ok=True)
+
     def save(self, fname, output):
         txt = json.dumps(output)
 
         outfile = os.path.join(self.folder, fname)
-        with open(outfile,"w",encoding="utf-8") as f:
+        with open(outfile, "w", encoding="utf-8") as f:
             f.write(txt)
         return txt
+
+
 class CorrectOutput(object):
     def __init__(self, file, fn_name):
         path, fname = os.path.split(file)
         self.folder = os.path.join(path, "output", fname, fn_name)
-        
+
     def load(self, fname):
         infile = os.path.join(self.folder, fname)
         with open(infile, encoding="utf-8") as f:
@@ -291,21 +332,25 @@ class CorrectOutput(object):
         output = json.loads(txt)
         return output
 
+
 def load_token_space_file(fname):
     path = make_abs_path("resources", fname)
     with open(path) as f:
         obj = json.load(f)
     return obj
 
+
 TOKEN_SPACE_MAP = load_token_space_file("token_space.json")
+
 
 def get_token_space(key):
     return TOKEN_SPACE_MAP.get(key, [None, None, None])
+
 
 def get_conn_info(key):
     conn_info = SpaceConnectionInfo()
     token, space_id, server = get_token_space(key)
     server = NetManager.API_URL.get(server, server)
     if token is not None:
-        conn_info.set_(token=token,space_id=space_id,server=server)
+        conn_info.set_(token=token, space_id=space_id, server=server)
     return conn_info


### PR DESCRIPTION
+ Ensure xyz_id uniqueness via sqlite trigger instead of 'on replace conflict' constraint
+ Ensure fields to be consistent with provider fields to avoid data corruption, especially after editing
  + map_fields, feat.fields
+ Ensure the paired order of fields-vector layer after a layer is removed (set fields to empty for deleted layer)
+ Handle virtual fields (expression field) in data loading
  + virtual fields shall never be appended to provider fields, it only stays as vector layer fields
  + related to #38
+ Update test for parser and render
+ Disconnect signal silently to avoid exception